### PR TITLE
feat: add star/favorite app system with localStorage

### DIFF
--- a/src/components/AppCard.vue
+++ b/src/components/AppCard.vue
@@ -5,6 +5,7 @@ import type { App } from '@/types';
 import { getProtocolInfo } from '@/utils/global.ts';
 import { ref, onMounted, onUnmounted, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { useFavoritesStore } from '@/stores/favorites';
 
 const props = defineProps<{
   app: App;
@@ -12,6 +13,8 @@ const props = defineProps<{
 
 const { t } = useI18n();
 const base = import.meta.env.BASE_URL;
+const favoritesStore = useFavoritesStore();
+const isStarred = computed(() => favoritesStore.isStarred(props.app.name));
 
 let openCount = 0;
 
@@ -89,6 +92,16 @@ const slicedDescription = computed(() => {
       :title="t('appModal.goodFirstApp')"
     >
       {{ t('appModal.goodFirstApp') }}
+    </div>
+    <!-- Star indicator for favorited apps -->
+    <div
+      v-if="isStarred"
+      class="absolute top-2 right-2 z-10 text-yellow-400 drop-shadow-md"
+      :aria-label="t('appModal.starred')"
+    >
+      <svg class="w-5 h-5 sm:w-6 sm:h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+      </svg>
     </div>
     <article class="w-full flex flex-row sm:flex-col">
       <figure class="p-2 w-20 sm:w-auto sm:p-10 sm:h-64 flex items-center justify-center">

--- a/src/components/AppModal.vue
+++ b/src/components/AppModal.vue
@@ -7,6 +7,7 @@ import { getAppSlug } from '@/utils/global.ts';
 import type { App } from '@/types';
 import { useI18n } from 'vue-i18n';
 import { useRoute } from 'vue-router';
+import { useFavoritesStore } from '@/stores/favorites';
 
 
 const { abrir, app } = defineProps<{
@@ -174,6 +175,18 @@ const protocolInfos = computed(() =>
 
 const { t } = useI18n();
 
+const favoritesStore = useFavoritesStore();
+
+const isCurrentAppStarred = computed(() =>
+  localApp.value.name ? favoritesStore.isStarred(localApp.value.name) : false
+);
+
+function toggleStar() {
+  if (localApp.value.name) {
+    favoritesStore.toggleStar(localApp.value.name);
+  }
+}
+
 </script>
 
 
@@ -329,6 +342,19 @@ const { t } = useI18n();
 
                 {{ link.label }}
               </a>
+              <!-- Star Button -->
+              <button
+                type="button"
+                class="btn btn-sm flex items-center gap-2"
+                :class="isCurrentAppStarred ? 'btn-warning' : 'btn-outline'"
+                @click="toggleStar"
+                :aria-label="isCurrentAppStarred ? t('appModal.unstar') : t('appModal.star')"
+                :aria-pressed="isCurrentAppStarred"
+              >
+                <svg class="w-4 h-4" :fill="isCurrentAppStarred ? 'currentColor' : 'none'" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+                </svg>{{ isCurrentAppStarred ? t('appModal.unstar') : t('appModal.star') }}
+              </button>
               <!-- Share Button -->
               <button
                 type="button"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -55,11 +55,26 @@
     }
   },
   "category": {
-    "all": { "name": "All", "short": "All" },
-    "social": { "name": "Social Networks", "short": "Social" },
-    "messaging": { "name": "Messengers", "short": "Messages" },
-    "tools": { "name": "Professional Tools", "short": "Tools" },
-    "protocols": { "name": "Open Protocols", "short": "Protocols" }
+    "all": {
+      "name": "All",
+      "short": "All"
+    },
+    "social": {
+      "name": "Social Networks",
+      "short": "Social"
+    },
+    "messaging": {
+      "name": "Messengers",
+      "short": "Messages"
+    },
+    "tools": {
+      "name": "Professional Tools",
+      "short": "Tools"
+    },
+    "protocols": {
+      "name": "Open Protocols",
+      "short": "Protocols"
+    }
   },
   "appModal": {
     "close": "Close",
@@ -70,7 +85,10 @@
     "br": "BR",
     "goodFirstApp": "Great first app",
     "selfHostingLabel": "Self-hosting difficulty",
-    "selfHostingTooltip": "How hard it is to self-host this app (1=Easy, 3=Advanced)"
+    "selfHostingTooltip": "How hard it is to self-host this app (1=Easy, 3=Advanced)",
+    "star": "Star",
+    "unstar": "Unstar",
+    "starred": "Starred app"
   },
   "surpriseMe": {
     "button": "Surprise me!"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -55,11 +55,26 @@
     }
   },
   "category": {
-    "all": { "name": "Todos", "short": "Todos" },
-    "social": { "name": "Redes Sociales", "short": "Sociales" },
-    "messaging": { "name": "Mensajeros", "short": "Mensajeros" },
-    "tools": { "name": "Herramientas Profesionales", "short": "Profesionales" },
-    "protocols": { "name": "Protocolos Abiertos", "short": "Protocolos" }
+    "all": {
+      "name": "Todos",
+      "short": "Todos"
+    },
+    "social": {
+      "name": "Redes Sociales",
+      "short": "Sociales"
+    },
+    "messaging": {
+      "name": "Mensajeros",
+      "short": "Mensajeros"
+    },
+    "tools": {
+      "name": "Herramientas Profesionales",
+      "short": "Profesionales"
+    },
+    "protocols": {
+      "name": "Protocolos Abiertos",
+      "short": "Protocolos"
+    }
   },
   "appModal": {
     "close": "Cerrar",
@@ -70,7 +85,10 @@
     "br": "BR",
     "goodFirstApp": "Excelente primera app",
     "selfHostingLabel": "Dificultad de auto-hospedaje",
-    "selfHostingTooltip": "Qué tan difícil es auto-hospedar esta app (1=Fácil, 3=Avanzado)"
+    "selfHostingTooltip": "Qué tan difícil es auto-hospedar esta app (1=Fácil, 3=Avanzado)",
+    "star": "Favorito",
+    "unstar": "Quitar favorito",
+    "starred": "App favorita"
   },
   "surpriseMe": {
     "button": "¡Sorpréndeme!"

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -55,11 +55,26 @@
     }
   },
   "category": {
-    "all": { "name": "Todos", "short": "Todos" },
-    "social": { "name": "Redes Sociais", "short": "Sociais" },
-    "messaging": { "name": "Mensageiros", "short": "Mensageiros" },
-    "tools": { "name": "Ferramentas Profissionais", "short": "Profissionais" },
-    "protocols": { "name": "Protocolos Abertos", "short": "Protocolos" }
+    "all": {
+      "name": "Todos",
+      "short": "Todos"
+    },
+    "social": {
+      "name": "Redes Sociais",
+      "short": "Sociais"
+    },
+    "messaging": {
+      "name": "Mensageiros",
+      "short": "Mensageiros"
+    },
+    "tools": {
+      "name": "Ferramentas Profissionais",
+      "short": "Profissionais"
+    },
+    "protocols": {
+      "name": "Protocolos Abertos",
+      "short": "Protocolos"
+    }
   },
   "appModal": {
     "close": "Fechar",
@@ -70,7 +85,10 @@
     "br": "BR",
     "goodFirstApp": "Ótimo primeiro app",
     "selfHostingLabel": "Dificuldade de auto-hospedagem",
-    "selfHostingTooltip": "Quão difícil é auto-hospedar este app (1=Fácil, 3=Avançado)"
+    "selfHostingTooltip": "Quão difícil é auto-hospedar este app (1=Fácil, 3=Avançado)",
+    "star": "Favoritar",
+    "unstar": "Desfavoritar",
+    "starred": "App favoritado"
   },
   "surpriseMe": {
     "button": "Me surpreenda!"

--- a/src/stores/favorites.ts
+++ b/src/stores/favorites.ts
@@ -1,0 +1,30 @@
+import { ref, computed } from 'vue';
+import { defineStore } from 'pinia';
+
+export const useFavoritesStore = defineStore(
+  'favorites',
+  () => {
+    const starred = ref<string[]>([]);
+
+    const isStarred = (appName: string) => starred.value.includes(appName);
+
+    const toggleStar = (appName: string) => {
+      const index = starred.value.indexOf(appName);
+      if (index === -1) {
+        starred.value.push(appName);
+      } else {
+        starred.value.splice(index, 1);
+      }
+    };
+
+    const count = computed(() => starred.value.length);
+
+    return { starred, isStarred, toggleStar, count };
+  },
+  {
+    persist: {
+      pick: ['starred'],
+      storage: localStorage,
+    },
+  },
+);


### PR DESCRIPTION
## Summary

Implements a star/favorite system for apps, allowing users to mark their favorite apps with persistent localStorage storage.

Closes #66

/attempt #66

## Changes

- **New store**: `src/stores/favorites.ts` — Pinia store managing starred app names with `pinia-plugin-persistedstate` for localStorage persistence
- **AppModal.vue**: Added star/unstar toggle button with filled/outline star icon, `btn-warning` style when starred, full accessibility (aria-pressed, aria-label)
- **AppCard.vue**: Added yellow star indicator (top-right corner) on favorited app cards
- **Locales**: Added i18n translations for star/unstar/starred in English, Portuguese, and Spanish

## Features

- Toggle star from the app modal via a dedicated button
- Visual star indicator on app cards for quick identification of favorites
- Data persists across sessions via localStorage
- Fully accessible with ARIA attributes
- Internationalized (en/pt/es)

## Test plan

- [ ] Open an app modal and click the Star button — it should toggle to "Unstar" with warning style
- [ ] Close and reopen the modal — star state should persist
- [ ] Check the app card shows a yellow star icon in the top-right corner
- [ ] Refresh the page — favorites should persist from localStorage
- [ ] Test in all three languages (en/pt/es)

🤖 Generated with [Claude Code](https://claude.com/claude-code)