### PR TITLE
feat: add navigation arrows to AppModal (#77)

### DIFF
--- a/src/components/AppModal.vue
+++ b/src/components/AppModal.vue
@@ -9,12 +9,14 @@ import { useI18n } from 'vue-i18n';
 import { useRoute } from 'vue-router';
 
 
-const { abrir, app } = defineProps<{
+const { abrir, app, hasPrev, hasNext } = defineProps<{
   abrir: boolean;
   app: Partial<App> & { _openCount?: number };
+  hasPrev?: boolean;
+  hasNext?: boolean;
 }>();
 
-const emit = defineEmits(['atualizarAbrir'])
+const emit = defineEmits(['atualizarAbrir', 'navigate-prev', 'navigate-next'])
 
 const expandido = ref(false);
 
@@ -180,12 +182,14 @@ const { t } = useI18n();
 <template>
   <div>
   <!-- ✅ Atualizado aqui: @cancel → @click.self -->
-  <dialog 
-    ref="myModal" 
+  <dialog
+    ref="myModal"
     :key="app._openCount"
-    class="modal fixed inset-0 flex items-center justify-center p-2 sm:p-4 overflow-auto" 
+    class="modal fixed inset-0 flex items-center justify-center p-2 sm:p-4 overflow-auto"
     @click.self="closeModal"
     @close="handleDialogClose"
+    @keydown.left.prevent="hasPrev && emit('navigate-prev')"
+    @keydown.right.prevent="hasNext && emit('navigate-next')"
     role="dialog"
     :aria-label="t('appModal.details', { name: localApp.name })"
     aria-modal="true"
@@ -201,6 +205,32 @@ const { t } = useI18n();
     >
       {{ t('appModal.linkCopied') || 'Link copied!' }}
     </div>
+
+    <!-- Navigation arrows -->
+    <button
+      v-if="hasPrev !== undefined"
+      type="button"
+      class="absolute top-1/2 -translate-y-1/2 left-2 z-20 bg-base-200 hover:bg-base-300 rounded-full p-2 shadow-md disabled:opacity-30 disabled:cursor-not-allowed"
+      :disabled="!hasPrev"
+      :aria-label="t('appModal.prevApp') || 'Previous app'"
+      @click="emit('navigate-prev')"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 stroke-current" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+      </svg>
+    </button>
+    <button
+      v-if="hasNext !== undefined"
+      type="button"
+      class="absolute top-1/2 -translate-y-1/2 right-14 z-20 bg-base-200 hover:bg-base-300 rounded-full p-2 shadow-md disabled:opacity-30 disabled:cursor-not-allowed"
+      :disabled="!hasNext"
+      :aria-label="t('appModal.nextApp') || 'Next app'"
+      @click="emit('navigate-next')"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 stroke-current" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+      </svg>
+    </button>
 
     <!-- Botão de fechar -->
     <button

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -23,6 +23,7 @@ const globalStore = useGlobalStore();
 const { updateSEO } = useSEO();
 
 const modalData = ref<Partial<App>>({});
+const currentModalIndex = ref<number>(-1);
 const searchQuery = ref('');
 const selectedCategory = ref<CategoryId>('all');
 const showFilters = ref(false);
@@ -92,13 +93,38 @@ onUnmounted(() => {
 
 function handleAbrirModal(app: App) {
   if (isUpdatingFromURL.value) return;
+  const index = filteredApps.value.findIndex((a) => a.name === app.name);
+  currentModalIndex.value = index;
   modalData.value = {};
   nextTick(() => {
     modalData.value = { ...app };
     mostrarModal.value = true;
     router.replace({ query: { ...route.query, app: getAppSlug(app) } });
-
   });
+}
+
+function handleNavigatePrev() {
+  if (currentModalIndex.value > 0) {
+    const prevApp = filteredApps.value[currentModalIndex.value - 1];
+    currentModalIndex.value -= 1;
+    modalData.value = {};
+    nextTick(() => {
+      modalData.value = { ...prevApp };
+      router.replace({ query: { ...route.query, app: getAppSlug(prevApp) } });
+    });
+  }
+}
+
+function handleNavigateNext() {
+  if (currentModalIndex.value < filteredApps.value.length - 1) {
+    const nextApp = filteredApps.value[currentModalIndex.value + 1];
+    currentModalIndex.value += 1;
+    modalData.value = {};
+    nextTick(() => {
+      modalData.value = { ...nextApp };
+      router.replace({ query: { ...route.query, app: getAppSlug(nextApp) } });
+    });
+  }
 }
 
 function handleSurpriseMe(app: App) {
@@ -224,6 +250,14 @@ watch([searchQuery, selectedCategory], ([query, category]) => {
   >
     <AppCard v-for="app in filteredApps" :key="app.name" :app="app" @abrir="handleAbrirModal" />
 
-    <AppModal :abrir="mostrarModal" :app="modalData" @atualizarAbrir="handleFecharModal" />
+    <AppModal
+      :abrir="mostrarModal"
+      :app="modalData"
+      :has-prev="currentModalIndex > 0"
+      :has-next="currentModalIndex < filteredApps.length - 1"
+      @atualizarAbrir="handleFecharModal"
+      @navigate-prev="handleNavigatePrev"
+      @navigate-next="handleNavigateNext"
+    />
   </section>
 </template>


### PR DESCRIPTION
## Summary

Closes #77

/attempt 77

- Added left (`←`) and right (`→`) arrow buttons inside `AppModal.vue` so users can navigate to the previous/next app without closing the modal
- Buttons are **disabled** (with reduced opacity) when there is no previous or next app available
- Added **keyboard support**: pressing the left/right arrow keys while the modal is open triggers navigation
- `HomeView.vue` tracks `currentModalIndex` to know which app is currently open and passes `hasPrev`/`hasNext` boolean props to `AppModal`
- Navigation events (`navigate-prev`, `navigate-next`) bubble back up to `HomeView` to update modal data and the URL query param

## Test plan

- [ ] Open the modal for any app — both arrows should appear
- [ ] The **left arrow** is disabled on the first app, the **right arrow** is disabled on the last app
- [ ] Clicking an enabled arrow loads the adjacent app in the modal
- [ ] Pressing `←` / `→` keyboard keys navigates while modal is open
- [ ] URL `?app=` query param updates correctly on each navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)