### PR TITLE
feat: add use-case category filter tags to app browsing interface

### DIFF
--- a/src/components/form/UseCaseFilter.vue
+++ b/src/components/form/UseCaseFilter.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import type { UseCaseId } from '@/types';
+import { useCases } from '@/data/useCases';
+import { useI18n } from 'vue-i18n';
+
+const props = defineProps<{
+  modelValue: UseCaseId[];
+}>();
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: UseCaseId[]): void;
+}>();
+
+const { t } = useI18n();
+
+function toggleUseCase(id: UseCaseId) {
+  const current = [...props.modelValue];
+  const index = current.indexOf(id);
+  if (index >= 0) {
+    current.splice(index, 1);
+  } else {
+    current.push(id);
+  }
+  emit('update:modelValue', current);
+}
+
+function clearAll() {
+  emit('update:modelValue', []);
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-2">
+    <div class="flex flex-wrap gap-2 justify-center">
+      <button
+        v-for="useCase in useCases"
+        :key="useCase.id"
+        type="button"
+        class="px-3 py-1 text-xs rounded-full border transition-colors duration-200 whitespace-nowrap focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-1"
+        :class="modelValue.includes(useCase.id)
+          ? 'bg-[var(--color-selected-radio)] text-gray-100 border-transparent'
+          : 'bg-base-100 text-base-content border-base-content/30 hover:bg-base-content/10'"
+        :aria-pressed="modelValue.includes(useCase.id)"
+        @click="toggleUseCase(useCase.id)"
+      >
+        {{ t('useCase.' + useCase.id) }}
+      </button>
+      <button
+        v-if="modelValue.length > 0"
+        type="button"
+        class="px-3 py-1 text-xs rounded-full border border-error/50 text-error bg-base-100 hover:bg-error/10 transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-error focus:ring-offset-1"
+        @click="clearAll"
+      >
+        {{ t('useCase.clearAll') }}
+      </button>
+    </div>
+  </div>
+</template>

--- a/src/data/apps.ts
+++ b/src/data/apps.ts
@@ -24,6 +24,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['social', 'tools'],
+    useCases: ['media', 'social-networking'],
     alternatives: ['YouTube', 'Vimeo'],
     protocol: ['ActivityPub', 'Fediverso'],
     banner: {
@@ -60,6 +61,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['social'],
+    useCases: ['social-networking', 'communication'],
     alternatives: ['Twitter', 'X.com'],
     protocol: ['ActivityPub', 'Fediverso'],
     banner: {
@@ -93,6 +95,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['tools'],
+    useCases: ['cloud-storage', 'documentation'],
     alternatives: ['Google Drive', 'OneDrive', 'Dropbox'],
     protocol: ['WebDAV'],
     recommendedForBeginners: true,
@@ -126,6 +129,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['tools'],
+    useCases: ['security'],
     alternatives: ['Google Password Manager'],
     recommendedForBeginners: true,
     banner: {
@@ -159,6 +163,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['tools'],
+    useCases: ['security'],
     alternatives: ['Google Password Manager'],
     banner: {
       src: './apps/icons/passbolt.svg',
@@ -189,6 +194,7 @@ export const apps: App[] = [
       { label: i18n.global.t('apps.element.links.3'), url: 'https://element.io/help/install' },
     ],
     categories: ['messaging'],
+    useCases: ['communication'],
     alternatives: ['WhatsApp', 'Telegram', 'Slack'],
     protocol: ['Matrix'],
     banner: {
@@ -219,6 +225,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['social'],
+    useCases: ['social-networking', 'communication'],
     alternatives: ['Reddit', 'Hacker News'],
     protocol: ['ActivityPub', 'Fediverso'],
     banner: {
@@ -253,6 +260,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['tools'],
+    useCases: ['video-conferencing', 'communication'],
     alternatives: ['Zoom', 'Google Meet'],
     protocol: ['WebRTC'],
     banner: {
@@ -287,6 +295,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['tools'],
+    useCases: ['documentation'],
     alternatives: ['Confluence', 'Notion', 'MediaWiki'],
     banner: {
       src: './apps/icons/bookstack.svg',
@@ -313,6 +322,7 @@ export const apps: App[] = [
       { label: i18n.global.t('apps.rsshub.links.3'), url: 'https://docs.rsshub.app/install/' },
     ],
     categories: ['tools'],
+    useCases: ['media'],
     alternatives: ['Newsletters'],
     protocol: ['RSS'],
     banner: {
@@ -346,6 +356,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['social', 'tools'],
+    useCases: ['social-networking', 'customer-support'],
     alternatives: ['Reddit', 'Facebook Groups'],
     banner: {
       src: './apps/icons/discourse.svg',
@@ -376,6 +387,7 @@ export const apps: App[] = [
       { label: i18n.global.t('apps.pixelfed.links.3'), url: 'https://docs.pixelfed.org/install/' },
     ],
     categories: ['social'],
+    useCases: ['social-networking'],
     alternatives: ['Instagram'],
     protocol: ['ActivityPub', 'Fediverso'],
     banner: {
@@ -407,6 +419,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['messaging'],
+    useCases: ['communication'],
     alternatives: ['WhatsApp', 'Telegram'],
     protocol: ['Signal Protocol'],
     recommendedForBeginners: true,
@@ -440,6 +453,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['tools'],
+    useCases: ['documentation'],
     alternatives: ['iLovePDF', 'SmallPDF'],
     recommendedForBeginners: true,
     banner: {
@@ -476,6 +490,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['protocols'],
+    useCases: ['communication'],
     alternatives: ['OStatus', 'Zot'],
     banner: {
       src: './apps/icons/activitypub.svg',
@@ -503,6 +518,7 @@ export const apps: App[] = [
       { label: i18n.global.t('apps.matrix.links.3'), url: 'https://matrix.org/ecosystem/clients/' },
     ],
     categories: ['protocols'],
+    useCases: ['communication'],
     alternatives: ['XMPP', 'Signal Protocol'],
     banner: {
       src: './apps/icons/matrix.svg',
@@ -533,6 +549,7 @@ export const apps: App[] = [
       { label: i18n.global.t('apps.xmpp.links.3'), url: 'https://xmpp.org/software/' },
     ],
     categories: ['protocols'],
+    useCases: ['communication'],
     alternatives: ['Matrix', 'Signal Protocol'],
     banner: {
       src: './apps/icons/xmpp.svg',
@@ -565,6 +582,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['protocols'],
+    useCases: ['communication'],
     protocol: ['SMTP', 'IMAP', 'POP3'],
     banner: {
       src: './apps/icons/email.svg',
@@ -592,6 +610,7 @@ export const apps: App[] = [
       { label: i18n.global.t('apps.ghost.links.3'), url: 'https://ghost.org/docs/install/' },
     ],
     categories: ['tools'],
+    useCases: ['documentation'],
     alternatives: ['WordPress', 'Medium'],
     banner: {
       src: './apps/icons/ghost.png',
@@ -626,6 +645,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['social'],
+    useCases: ['social-networking'],
     alternatives: ['Twitter', 'X.com'],
     protocol: ['ActivityPub', 'Fediverso'],
     banner: {
@@ -659,6 +679,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['messaging', 'tools'],
+    useCases: ['communication', 'customer-support'],
     alternatives: ['Slack', 'Microsoft Teams', 'Zendesk'],
     banner: {
       src: './apps/icons/rocketchat.svg',
@@ -685,6 +706,7 @@ export const apps: App[] = [
       { label: i18n.global.t('apps.plane.links.3'), url: 'https://docs.plane.so/' },
     ],
     categories: ['tools'],
+    useCases: ['project-management'],
     alternatives: ['Trello', 'Jira'],
     banner: {
       src: './apps/icons/plane.svg',
@@ -711,6 +733,7 @@ export const apps: App[] = [
       { label: i18n.global.t('apps.ipfs.links.3'), url: 'https://docs.ipfs.tech/install/' },
     ],
     categories: ['protocols'],
+    useCases: ['cloud-storage'],
     alternatives: ['HTTP', 'BitTorrent'],
     banner: {
       src: './apps/icons/ipfs.svg',
@@ -743,6 +766,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['tools'],
+    useCases: ['security'],
     alternatives: ['Google Password Manager'],
     banner: {
       src: './apps/icons/bitwarden.svg',
@@ -776,6 +800,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['social'],
+    useCases: ['social-networking'],
     alternatives: ['Facebook'],
     protocol: ['Diaspora protocol'],
     banner: {
@@ -809,6 +834,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['tools'],
+    useCases: ['media'],
     alternatives: ['Plex'],
     banner: {
       src: './apps/icons/jellyfin.svg',
@@ -838,6 +864,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['messaging', 'tools'],
+    useCases: ['communication'],
     alternatives: ['Slack', 'Microsoft Teams', 'Discord'],
     banner: {
       src: './apps/icons/zulip.svg',
@@ -870,6 +897,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['tools'],
+    useCases: ['customer-support'],
     alternatives: ['Zendesk', 'Freshdesk', 'Help Scout'],
     banner: {
       src: './apps/icons/osticket.png',
@@ -902,6 +930,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['social'],
+    useCases: ['social-networking'],
     alternatives: ['Facebook', 'Mastodon', 'Diaspora*'],
     protocol: ['ActivityPub', 'Diaspora protocol', 'OStatus'],
     banner: {
@@ -936,6 +965,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['social'],
+    useCases: ['social-networking'],
     alternatives: ['Mastodon', 'Misskey'],
     protocol: ['ActivityPub', 'Fediverso'],
     banner: {
@@ -966,6 +996,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['social', 'tools'],
+    useCases: ['social-networking', 'cloud-storage'],
     alternatives: ['Facebook', 'Diaspora*', 'Mastodon'],
     protocol: ['Zot', 'ActivityPub'],
     banner: {
@@ -999,6 +1030,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['messaging', 'tools'],
+    useCases: ['communication'],
     alternatives: ['Slack', 'Microsoft Teams', 'Rocket.Chat', 'GitLab'],
     banner: {
       src: './apps/icons/mattermost.svg',
@@ -1031,6 +1063,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['tools'],
+    useCases: ['video-conferencing'],
     alternatives: ['Zoom', 'Google Meet', 'Microsoft Teams'],
     protocol: ['WebRTC'],
     banner: {
@@ -1058,6 +1091,7 @@ export const apps: App[] = [
       { label: i18n.global.t('apps.gitlab.links.3'), url: 'https://about.gitlab.com/install/' },
     ],
     categories: ['tools'],
+    useCases: ['developer-tools'],
     alternatives: ['GitHub', 'Bitbucket', 'Gitea'],
     protocol: ['Git'],
     banner: {
@@ -1088,6 +1122,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['tools'],
+    useCases: ['developer-tools'],
     alternatives: ['GitHub', 'GitLab'],
     protocol: ['Git'],
     banner: {
@@ -1121,6 +1156,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['tools'],
+    useCases: ['project-management'],
     alternatives: ['Jira', 'Trello', 'Asana'],
     banner: {
       src: './apps/icons/openproject.svg',
@@ -1152,6 +1188,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['tools'],
+    useCases: ['monitoring'],
     alternatives: [''],
     banner: {
       src: './apps/icons/uptimekuma.svg',
@@ -1181,6 +1218,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['tools'],
+    useCases: ['media'],
     alternatives: ['Jellyfin', 'Emby', 'Kodi'],
     banner: {
       src: './apps/icons/plex.svg',
@@ -1213,6 +1251,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['tools'],
+    useCases: ['documentation'],
     alternatives: ['Grammarly', 'Microsoft Editor'],
     banner: {
       src: './apps/icons/languagetool.png',
@@ -1242,6 +1281,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['tools'],
+    useCases: ['media'],
     alternatives: ['Twitch', 'YouTube Live', 'Facebook Live'],
     banner: {
       src: './apps/icons/owncast.svg',
@@ -1271,6 +1311,7 @@ export const apps: App[] = [
       { label: i18n.global.t('apps.azuracast.links.3'), url: 'https://www.azuracast.com/install/' },
     ],
     categories: ['tools'],
+    useCases: ['media'],
     alternatives: ['Radio.co', 'Shoutcast'],
     banner: {
       src: './apps/icons/azuracast.svg',
@@ -1303,6 +1344,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['tools'],
+    useCases: ['security'],
     alternatives: ['Auth0', 'Okta', 'Firebase Auth'],
     protocol: ['OIDC', 'SAML', 'OAuth2'],
     banner: {
@@ -1336,6 +1378,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['tools'],
+    useCases: ['documentation'],
     alternatives: ['Ghost', 'Wix', 'Squarespace'],
     banner: {
       src: './apps/icons/wordpress.svg',
@@ -1365,6 +1408,7 @@ export const apps: App[] = [
       { label: i18n.global.t('apps.atprotocol.links.3'), url: 'https://blueskyweb.xyz/' },
     ],
     categories: ['protocols'],
+    useCases: ['communication'],
     alternatives: ['ActivityPub', 'Diaspora protocol'],
     banner: {
       src: './apps/icons/atprotocol.svg',
@@ -1392,6 +1436,7 @@ export const apps: App[] = [
       { label: i18n.global.t('apps.bluesky.links.3'), url: 'https://atproto.com/' },
     ],
     categories: ['social'],
+    useCases: ['social-networking'],
     alternatives: ['Twitter'],
     protocol: ['AT Protocol'],
     banner: {
@@ -1425,6 +1470,7 @@ export const apps: App[] = [
       { label: i18n.global.t('apps.rss.links.3'), url: 'https://rsshub.app/' },
     ],
     categories: ['protocols'],
+    useCases: ['media'],
     alternatives: ['Newsletters', 'Atom'],
     banner: {
       src: './apps/icons/rss.svg',
@@ -1454,6 +1500,7 @@ export const apps: App[] = [
       { label: i18n.global.t('apps.atom.links.3'), url: 'https://rsshub.app/' },
     ],
     categories: ['protocols'],
+    useCases: ['media'],
     alternatives: ['RSS', 'Newsletters'],
     banner: {
       src: './apps/icons/atom.svg',
@@ -1486,6 +1533,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['protocols'],
+    useCases: ['media'],
     alternatives: ['IPFS', 'HTTP', 'Resilio Sync'],
     banner: {
       src: './apps/icons/bittorrent.svg',
@@ -1518,6 +1566,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['protocols'],
+    useCases: ['communication', 'social-networking'],
     alternatives: ['ActivityPub', 'AT Protocol'],
     banner: {
       src: './apps/icons/nostr.svg',
@@ -1544,6 +1593,7 @@ export const apps: App[] = [
       { label: i18n.global.t('apps.tor.links.3'), url: 'https://support.torproject.org/pt-BR/' },
     ],
     categories: ['protocols'],
+    useCases: ['security'],
     alternatives: ['VPN', 'I2P', 'Proxy'],
     banner: {
       src: './apps/icons/tor.svg',
@@ -1573,6 +1623,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['tools'],
+    useCases: ['monitoring', 'developer-tools'],
     alternatives: ['Kibana', 'Datadog', 'Tableau'],
     banner: {
       src: './apps/icons/grafana.svg',
@@ -1605,6 +1656,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['tools'],
+    useCases: ['monitoring', 'developer-tools'],
     alternatives: ['Zabbix', 'Datadog'],
     banner: {
       src: './apps/icons/prometheus.svg',
@@ -1637,6 +1689,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['tools'],
+    useCases: ['media'],
     alternatives: ['Spotify', 'SoundCloud'],
     protocol: ['ActivityPub', 'Fediverso'],
     banner: {
@@ -1671,6 +1724,7 @@ export const apps: App[] = [
       { label: i18n.global.t('apps.irc.links.3'), url: 'https://tools.ietf.org/html/rfc1459' },
     ],
     categories: ['protocols'],
+    useCases: ['communication'],
     alternatives: ['Matrix', 'XMPP'],
     banner: {
       src: './apps/icons/irc.svg',
@@ -1703,6 +1757,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['tools'],
+    useCases: ['communication'],
     alternatives: ['Slack', 'Discord', 'Telegram', 'WhatsApp'],
     protocol: ['IRC'],
     banner: {
@@ -1733,6 +1788,7 @@ export const apps: App[] = [
       },
     ],
     categories: ['tools'],
+    useCases: ['documentation', 'cloud-storage'],
     alternatives: ['Google Workspace', 'Microsoft 365', 'Zoho Workplace'],
     banner: {
       src: './apps/icons/lasuite.svg',

--- a/src/data/useCases.ts
+++ b/src/data/useCases.ts
@@ -1,0 +1,15 @@
+import type { UseCase } from '../types';
+
+export const useCases: UseCase[] = [
+  { id: 'cloud-storage' },
+  { id: 'communication' },
+  { id: 'customer-support' },
+  { id: 'developer-tools' },
+  { id: 'documentation' },
+  { id: 'media' },
+  { id: 'monitoring' },
+  { id: 'project-management' },
+  { id: 'security' },
+  { id: 'social-networking' },
+  { id: 'video-conferencing' },
+];

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -55,11 +55,26 @@
     }
   },
   "category": {
-    "all": { "name": "All", "short": "All" },
-    "social": { "name": "Social Networks", "short": "Social" },
-    "messaging": { "name": "Messengers", "short": "Messages" },
-    "tools": { "name": "Professional Tools", "short": "Tools" },
-    "protocols": { "name": "Open Protocols", "short": "Protocols" }
+    "all": {
+      "name": "All",
+      "short": "All"
+    },
+    "social": {
+      "name": "Social Networks",
+      "short": "Social"
+    },
+    "messaging": {
+      "name": "Messengers",
+      "short": "Messages"
+    },
+    "tools": {
+      "name": "Professional Tools",
+      "short": "Tools"
+    },
+    "protocols": {
+      "name": "Open Protocols",
+      "short": "Protocols"
+    }
   },
   "appModal": {
     "close": "Close",
@@ -865,5 +880,20 @@
       "toggleDescription": "Click to expand or collapse description",
       "selectCategory": "Select category: {category}"
     }
+  },
+  "useCase": {
+    "cloud-storage": "Cloud Storage",
+    "communication": "Communication",
+    "customer-support": "Customer Support",
+    "developer-tools": "Developer Tools",
+    "documentation": "Documentation",
+    "media": "Media",
+    "monitoring": "Monitoring",
+    "project-management": "Project Management",
+    "security": "Security",
+    "social-networking": "Social Networking",
+    "video-conferencing": "Video Conferencing",
+    "clearAll": "Clear filters",
+    "label": "Filter by use case"
   }
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -55,11 +55,26 @@
     }
   },
   "category": {
-    "all": { "name": "Todos", "short": "Todos" },
-    "social": { "name": "Redes Sociales", "short": "Sociales" },
-    "messaging": { "name": "Mensajeros", "short": "Mensajeros" },
-    "tools": { "name": "Herramientas Profesionales", "short": "Profesionales" },
-    "protocols": { "name": "Protocolos Abiertos", "short": "Protocolos" }
+    "all": {
+      "name": "Todos",
+      "short": "Todos"
+    },
+    "social": {
+      "name": "Redes Sociales",
+      "short": "Sociales"
+    },
+    "messaging": {
+      "name": "Mensajeros",
+      "short": "Mensajeros"
+    },
+    "tools": {
+      "name": "Herramientas Profesionales",
+      "short": "Profesionales"
+    },
+    "protocols": {
+      "name": "Protocolos Abiertos",
+      "short": "Protocolos"
+    }
   },
   "appModal": {
     "close": "Cerrar",
@@ -859,5 +874,20 @@
         "3": "Código Fonte (parcial)"
       }
     }
+  },
+  "useCase": {
+    "cloud-storage": "Almacenamiento en la Nube",
+    "communication": "Comunicación",
+    "customer-support": "Atención al Cliente",
+    "developer-tools": "Herramientas de Dev",
+    "documentation": "Documentación",
+    "media": "Medios",
+    "monitoring": "Monitoreo",
+    "project-management": "Gestión de Proyectos",
+    "security": "Seguridad",
+    "social-networking": "Redes Sociales",
+    "video-conferencing": "Videoconferencia",
+    "clearAll": "Limpiar filtros",
+    "label": "Filtrar por uso"
   }
 }

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -55,11 +55,26 @@
     }
   },
   "category": {
-    "all": { "name": "Todos", "short": "Todos" },
-    "social": { "name": "Redes Sociais", "short": "Sociais" },
-    "messaging": { "name": "Mensageiros", "short": "Mensageiros" },
-    "tools": { "name": "Ferramentas Profissionais", "short": "Profissionais" },
-    "protocols": { "name": "Protocolos Abertos", "short": "Protocolos" }
+    "all": {
+      "name": "Todos",
+      "short": "Todos"
+    },
+    "social": {
+      "name": "Redes Sociais",
+      "short": "Sociais"
+    },
+    "messaging": {
+      "name": "Mensageiros",
+      "short": "Mensageiros"
+    },
+    "tools": {
+      "name": "Ferramentas Profissionais",
+      "short": "Profissionais"
+    },
+    "protocols": {
+      "name": "Protocolos Abertos",
+      "short": "Protocolos"
+    }
   },
   "appModal": {
     "close": "Fechar",
@@ -859,5 +874,20 @@
         "3": "Código Fonte (parcial)"
       }
     }
+  },
+  "useCase": {
+    "cloud-storage": "Armazenamento em Nuvem",
+    "communication": "Comunicação",
+    "customer-support": "Suporte ao Cliente",
+    "developer-tools": "Ferramentas de Dev",
+    "documentation": "Documentação",
+    "media": "Mídia",
+    "monitoring": "Monitoramento",
+    "project-management": "Gestão de Projetos",
+    "security": "Segurança",
+    "social-networking": "Redes Sociais",
+    "video-conferencing": "Videoconferência",
+    "clearAll": "Limpar filtros",
+    "label": "Filtrar por uso"
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,23 @@
 
 export type CategoryId = 'all' | 'social' | 'messaging' | 'tools' | 'protocols';
 
+export type UseCaseId =
+  | 'cloud-storage'
+  | 'communication'
+  | 'customer-support'
+  | 'developer-tools'
+  | 'documentation'
+  | 'media'
+  | 'monitoring'
+  | 'project-management'
+  | 'security'
+  | 'social-networking'
+  | 'video-conferencing';
+
+export interface UseCase {
+  id: UseCaseId;
+}
+
 export interface App {
   name: string;
   description: string; // usado no card
@@ -9,6 +26,7 @@ export interface App {
   features?: string[]; // bullet points
   links?: { label: string; url: string }[]; // botões
   categories: CategoryId[];
+  useCases?: UseCaseId[];
   alternatives?: string[];
   protocol?: string[];
   recommendedForBeginners?: boolean;

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -1,4 +1,4 @@
-import type { App, CategoryId } from '@/types';
+import type { App, CategoryId, UseCaseId } from '@/types';
 
 export function countInboundLinks(app: App): number {
   return (app.links || []).filter(link =>
@@ -32,7 +32,12 @@ export function shuffleAppsPurely(apps: App[]): App[] {
   return shuffleArray([...apps]);
 }
 
-export function filterApps(apps: App[], category: CategoryId, query: string): App[] {
+export function filterApps(
+  apps: App[],
+  category: CategoryId,
+  query: string,
+  selectedUseCases: UseCaseId[] = [],
+): App[] {
   const lowerQuery = query.toLowerCase();
   return apps.filter(app => {
     const isSameCategory =
@@ -40,6 +45,9 @@ export function filterApps(apps: App[], category: CategoryId, query: string): Ap
     const nameMatchesQuery =
       app.name.toLowerCase().includes(lowerQuery) ||
       (app.alternatives || []).some(alt => alt.toLowerCase().includes(lowerQuery));
-    return isSameCategory && nameMatchesQuery;
+    const matchesUseCases =
+      selectedUseCases.length === 0 ||
+      selectedUseCases.every(uc => (app.useCases || []).includes(uc));
+    return isSameCategory && nameMatchesQuery && matchesUseCases;
   });
 }

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -5,12 +5,13 @@ import AppSearch from '@/components/form/AppSearch.vue';
 import CategorySelector from '@/components/form/CategorySelector.vue';
 import ReshuffleButton from '@/components/form/ReshuffleButton.vue';
 import SurpriseMeButton from '@/components/form/SurpriseMeButton.vue';
+import UseCaseFilter from '@/components/form/UseCaseFilter.vue';
 import { useSEO } from '@/composables/useSEO';
 import { apps } from '@/data/apps';
 import { categories } from '@/data/categories';
 import { useGlobalStore } from '@/stores/global';
 import { useHeadersStore } from '@/stores/headers';
-import type { App, CategoryId } from '@/types';
+import type { App, CategoryId, UseCaseId } from '@/types';
 import { filterApps, shuffleAppsPurely, sortAppsByLinksThenRandom } from '@/utils/filter';
 import { getAppSlug } from '@/utils/global';
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
@@ -25,6 +26,7 @@ const { updateSEO } = useSEO();
 const modalData = ref<Partial<App>>({});
 const searchQuery = ref('');
 const selectedCategory = ref<CategoryId>('all');
+const selectedUseCases = ref<UseCaseId[]>([]);
 const showFilters = ref(false);
 const route = useRoute();
 const router = useRouter();
@@ -41,7 +43,7 @@ const orderedApps = computed(() => {
 });
 
 const filteredApps = computed(() => {
-  return filterApps(orderedApps.value, selectedCategory.value, searchQuery.value);
+  return filterApps(orderedApps.value, selectedCategory.value, searchQuery.value, selectedUseCases.value);
 });
 
 const title = computed(() => t('app.title'));
@@ -166,9 +168,9 @@ watch([mostrarModal, modalData], ([isOpen, app]) => {
 });
 
 // This is section watch for search/filter changes to update SEO
-watch([searchQuery, selectedCategory], ([query, category]) => {
-  // Reset reshuffle when user searches or changes category
-  if ((query && query.length > 0) || category !== 'all') {
+watch([searchQuery, selectedCategory, selectedUseCases], ([query, category, useCases]) => {
+  // Reset reshuffle when user searches or changes category or use cases
+  if ((query && query.length > 0) || category !== 'all' || (useCases as UseCaseId[]).length > 0) {
     globalStore.resetReshuffle();
   }
 
@@ -199,6 +201,7 @@ watch([searchQuery, selectedCategory], ([query, category]) => {
 
   <section class="w-full space-y-5">
     <CategorySelector v-if="showFilters" v-model="selectedCategory" :categories="categories" />
+    <UseCaseFilter v-if="showFilters" v-model="selectedUseCases" />
     <div class="mb-8 flex gap-2 items-start w-full">
       <div class="flex-1 min-w-0">
         <AppSearch


### PR DESCRIPTION
## Summary

Implements filtering by practical real-world use cases as requested in #62.

### What was done

- **`src/types.ts`** — Added `UseCaseId` union type (11 use cases) and optional `useCases` field to the `App` interface
- **`src/data/useCases.ts`** (new) — Extensible use case list; easy to add/rename future tags
- **`src/data/apps.ts`** — All 56 apps annotated with appropriate `useCases` tags
- **`src/components/form/UseCaseFilter.vue`** (new) — Multi-select tag-pill component inspired by `CategorySelector.vue`; supports toggling individual tags and a "Clear filters" button
- **`src/utils/filter.ts`** — `filterApps()` extended with `selectedUseCases` parameter (AND logic: app must match all selected tags)
- **`src/views/HomeView.vue`** — `UseCaseFilter` integrated below `CategorySelector`, shown when the search bar is focused; connected to `filteredApps` computed
- **`src/locales/en.json`, `pt.json`, `es.json`** — Full i18n translations for all use case labels and UI strings

### Use cases supported

`cloud-storage` · `communication` · `customer-support` · `developer-tools` · `documentation` · `media` · `monitoring` · `project-management` · `security` · `social-networking` · `video-conferencing`

### Design notes

- Tags work alongside the existing category selector and search — all three filters are ANDed together
- Multi-select: users can combine tags (e.g. "communication + security")
- Fully internationalised (en/pt/es)
- Structure is extensible: add a new entry to `useCases.ts`, annotate apps, add translation key

/attempt 62

Closes #62