### PR TITLE
feat: add prev/next navigation arrows to app modal

### DIFF
--- a/src/components/AppModal.vue
+++ b/src/components/AppModal.vue
@@ -9,12 +9,14 @@ import { useI18n } from 'vue-i18n';
 import { useRoute } from 'vue-router';
 
 
-const { abrir, app } = defineProps<{
+const { abrir, app, appList, currentIndex } = defineProps<{
   abrir: boolean;
   app: Partial<App> & { _openCount?: number };
+  appList?: App[];
+  currentIndex?: number;
 }>();
 
-const emit = defineEmits(['atualizarAbrir'])
+const emit = defineEmits(['atualizarAbrir', 'navigate'])
 
 const expandido = ref(false);
 
@@ -172,6 +174,35 @@ const protocolInfos = computed(() =>
     .filter((info): info is { src: string; alt: string; url: string } => !!info)
 );
 
+const hasPrev = computed(() => appList && appList.length > 1 && currentIndex !== undefined && currentIndex > 0);
+const hasNext = computed(() => appList && appList.length > 1 && currentIndex !== undefined && currentIndex < appList.length - 1);
+
+function navigatePrev() {
+  if (hasPrev.value && currentIndex !== undefined) {
+    emit('navigate', currentIndex - 1);
+  }
+}
+
+function navigateNext() {
+  if (hasNext.value && currentIndex !== undefined) {
+    emit('navigate', currentIndex + 1);
+  }
+}
+
+function handleKeydown(e: KeyboardEvent) {
+  if (!abrir) return;
+  if (e.key === 'ArrowLeft') navigatePrev();
+  else if (e.key === 'ArrowRight') navigateNext();
+}
+
+onMounted(() => {
+  window.addEventListener('keydown', handleKeydown);
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', handleKeydown);
+});
+
 const { t } = useI18n();
 
 </script>
@@ -191,6 +222,35 @@ const { t } = useI18n();
     aria-modal="true"
   >
   <div v-if="visible" class="modal-box w-full max-w-[880px] max-h-[calc(100vh-2rem)] overflow-y-auto rounded-xl relative bg-base-100 sm:px-6 sm:py-6 box-border">
+
+    <!-- Navigation arrows -->
+    <button
+      v-if="appList && appList.length > 1"
+      type="button"
+      class="absolute left-2 top-1/2 -translate-y-1/2 z-20 bg-base-200 hover:bg-base-300 rounded-full p-2 shadow-md transition-opacity"
+      :class="{ 'opacity-30 cursor-not-allowed': !hasPrev }"
+      :disabled="!hasPrev"
+      @click="navigatePrev"
+      :aria-label="t('appModal.prevApp')"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 stroke-current" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+      </svg>
+    </button>
+    <button
+      v-if="appList && appList.length > 1"
+      type="button"
+      class="absolute right-14 top-1/2 -translate-y-1/2 z-20 bg-base-200 hover:bg-base-300 rounded-full p-2 shadow-md transition-opacity"
+      :class="{ 'opacity-30 cursor-not-allowed': !hasNext }"
+      :disabled="!hasNext"
+      @click="navigateNext"
+      :aria-label="t('appModal.nextApp')"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 stroke-current" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+      </svg>
+    </button>
+
     <!-- Move toast inside the dialog -->
     <div
       v-if="shareToast"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -70,7 +70,10 @@
     "br": "BR",
     "goodFirstApp": "Great first app",
     "selfHostingLabel": "Self-hosting difficulty",
-    "selfHostingTooltip": "How hard it is to self-host this app (1=Easy, 3=Advanced)"
+    "selfHostingTooltip": "How hard it is to self-host this app (1=Easy, 3=Advanced)",
+    "prevApp": "Previous app",
+    "nextApp": "Next app",
+    "details": "{name} details"
   },
   "surpriseMe": {
     "button": "Surprise me!"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -70,7 +70,10 @@
     "br": "BR",
     "goodFirstApp": "Excelente primera app",
     "selfHostingLabel": "Dificultad de auto-hospedaje",
-    "selfHostingTooltip": "Qué tan difícil es auto-hospedar esta app (1=Fácil, 3=Avanzado)"
+    "selfHostingTooltip": "Qué tan difícil es auto-hospedar esta app (1=Fácil, 3=Avanzado)",
+    "prevApp": "App anterior",
+    "nextApp": "App siguiente",
+    "details": "Detalles de {name}"
   },
   "surpriseMe": {
     "button": "¡Sorpréndeme!"

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -70,7 +70,10 @@
     "br": "BR",
     "goodFirstApp": "Ótimo primeiro app",
     "selfHostingLabel": "Dificuldade de auto-hospedagem",
-    "selfHostingTooltip": "Quão difícil é auto-hospedar este app (1=Fácil, 3=Avançado)"
+    "selfHostingTooltip": "Quão difícil é auto-hospedar este app (1=Fácil, 3=Avançado)",
+    "prevApp": "App anterior",
+    "nextApp": "Próximo app",
+    "details": "Detalhes de {name}"
   },
   "surpriseMe": {
     "button": "Me surpreenda!"

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -23,6 +23,7 @@ const globalStore = useGlobalStore();
 const { updateSEO } = useSEO();
 
 const modalData = ref<Partial<App>>({});
+const currentModalIndex = ref(-1);
 const searchQuery = ref('');
 const selectedCategory = ref<CategoryId>('all');
 const showFilters = ref(false);
@@ -92,13 +93,22 @@ onUnmounted(() => {
 
 function handleAbrirModal(app: App) {
   if (isUpdatingFromURL.value) return;
+  const index = filteredApps.value.findIndex(a => a.name === app.name);
   modalData.value = {};
   nextTick(() => {
     modalData.value = { ...app };
+    currentModalIndex.value = index;
     mostrarModal.value = true;
     router.replace({ query: { ...route.query, app: getAppSlug(app) } });
-
   });
+}
+
+function handleNavigate(index: number) {
+  const app = filteredApps.value[index];
+  if (!app) return;
+  modalData.value = { ...app };
+  currentModalIndex.value = index;
+  router.replace({ query: { ...route.query, app: getAppSlug(app) } });
 }
 
 function handleSurpriseMe(app: App) {
@@ -224,6 +234,13 @@ watch([searchQuery, selectedCategory], ([query, category]) => {
   >
     <AppCard v-for="app in filteredApps" :key="app.name" :app="app" @abrir="handleAbrirModal" />
 
-    <AppModal :abrir="mostrarModal" :app="modalData" @atualizarAbrir="handleFecharModal" />
+    <AppModal
+      :abrir="mostrarModal"
+      :app="modalData"
+      :appList="filteredApps"
+      :currentIndex="currentModalIndex"
+      @atualizarAbrir="handleFecharModal"
+      @navigate="handleNavigate"
+    />
   </section>
 </template>


### PR DESCRIPTION
## Summary

Implements issue #77 — adds left/right navigation arrows inside the app modal so users can browse through the current filtered list without closing and reopening the modal.

## Changes

- **`AppModal.vue`**: Added two arrow buttons (left ← / right →) absolutely positioned on the sides of the modal. Arrows are disabled when at the first or last item in the list. Also added keyboard support: pressing the left/right arrow keys navigates between apps while the modal is open.
- **`HomeView.vue`**: Passes `filteredApps` (the current filtered list) and `currentModalIndex` to `AppModal`. Handles the new `navigate` emit to update `modalData` and the URL query param reactively.
- **Locales (`en`, `pt`, `es`)**: Added `prevApp`, `nextApp`, and `details` i18n keys.

## Behaviour

- Left arrow → previous app in the filtered list (disabled at index 0)
- Right arrow → next app in the filtered list (disabled at last index)
- Keyboard: ← / → arrow keys work when the modal is open
- Navigation respects active search and category filters
- URL (`?app=slug`) updates on each navigation step

Closes #77