### PR TITLE
feat: modal previous/next app navigation (#77)

### DIFF
--- a/src/components/AppModal.vue
+++ b/src/components/AppModal.vue
@@ -1,20 +1,26 @@
 <script setup lang="ts">
-import { ref, type Ref, defineProps, watch, onMounted, onBeforeUnmount, nextTick, computed } from 'vue'
+import { ref, type Ref, watch, onMounted, onBeforeUnmount, nextTick, computed } from 'vue'
 import { getAlternativeIcon } from '@/utils/global.ts';
 import { getProtocolInfo } from '@/utils/global.ts';
 import { getFaviconPath } from '@/utils/global.ts';
 import { getAppSlug } from '@/utils/global.ts';
+import { canGoNext, canGoPrevious, getNextApp, getPreviousApp } from '@/utils/modalNavigation';
 import type { App } from '@/types';
 import { useI18n } from 'vue-i18n';
 import { useRoute } from 'vue-router';
 
 
-const { abrir, app } = defineProps<{
+const props = defineProps<{
   abrir: boolean;
   app: Partial<App> & { _openCount?: number };
+  /** Currently visible apps (after filters/search) used for prev/next navigation. */
+  apps?: App[];
 }>();
 
-const emit = defineEmits(['atualizarAbrir'])
+const emit = defineEmits<{
+  atualizarAbrir: [value: boolean];
+  navigate: [app: App];
+}>();
 
 const expandido = ref(false);
 
@@ -31,24 +37,59 @@ const myModal = ref<HTMLDialogElement | null>(null)
 
 const previousActiveElement = ref<HTMLElement | null>(null);
 
-watch(() => abrir, async (newValue) => {
-  if (newValue && app) {
+const visibleApps = computed(() => props.apps ?? []);
+
+const hasPrevious = computed(() => canGoPrevious(visibleApps.value, localApp.value.name));
+const hasNext = computed(() => canGoNext(visibleApps.value, localApp.value.name));
+
+function goToPrevious() {
+  const prev = getPreviousApp(visibleApps.value, localApp.value.name);
+  if (prev) emit('navigate', prev);
+}
+
+function goToNext() {
+  const next = getNextApp(visibleApps.value, localApp.value.name);
+  if (next) emit('navigate', next);
+}
+
+function onKeydown(event: KeyboardEvent) {
+  if (!props.abrir || !visible.value) return;
+  const target = event.target as HTMLElement | null;
+  if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) {
+    return;
+  }
+  if (event.key === 'ArrowLeft') {
+    event.preventDefault();
+    goToPrevious();
+  } else if (event.key === 'ArrowRight') {
+    event.preventDefault();
+    goToNext();
+  }
+}
+
+async function loadAppIntoModal(source: Partial<App>) {
+  bannerErrored.value = false;
+  expandido.value = false;
+  visible.value = false;
+  localApp.value = {};
+  visibleAlternatives.value = {};
+  favicons.value = [];
+
+  await nextTick();
+
+  localApp.value = { ...source };
+  visible.value = true;
+}
+
+watch(() => props.abrir, async (newValue) => {
+  if (newValue && props.app) {
     previousActiveElement.value = document.activeElement as HTMLElement;
-    bannerErrored.value = false;
-    expandido.value = false;
-    visible.value = false;
-    localApp.value = {};
-    visibleAlternatives.value = {}; 
-    favicons.value = [];
 
-    await nextTick();
+    await loadAppIntoModal(props.app);
 
-    localApp.value = { ...app };
-    visible.value = true;
-    
     await nextTick();
     myModal.value?.showModal();
-    
+
     const firstFocusable = myModal.value?.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])') as HTMLElement;
     if (firstFocusable) {
       firstFocusable.focus();
@@ -60,8 +101,17 @@ watch(() => abrir, async (newValue) => {
   }
 });
 
-watch(() => app._openCount, async (newValue) => {
-  if (!app || !newValue) return;
+// Keep modal content in sync when parent navigates to another app while open.
+watch(
+  () => props.app.name,
+  async (newName, oldName) => {
+    if (!props.abrir || !newName || newName === oldName) return;
+    await loadAppIntoModal(props.app);
+  },
+);
+
+watch(() => props.app._openCount, async (newValue) => {
+  if (!props.app || !newValue) return;
 });
 
 function handleDialogClose() {
@@ -138,6 +188,8 @@ watch(
         const { src, visible, onError } = faviconSrc(link.url);
         return { ...link, faviconSrc: src, faviconVisible: visible, faviconError: onError };
       });
+    } else {
+      favicons.value = [];
     }
   },
   { immediate: true }
@@ -148,10 +200,12 @@ const isMobile = ref(false);
 onMounted(() => {
   isMobile.value = window.innerWidth < 640;
   window.addEventListener('resize', handleResize);
+  window.addEventListener('keydown', onKeydown);
 });
 
 onBeforeUnmount(() => {
   window.removeEventListener('resize', handleResize);
+  window.removeEventListener('keydown', onKeydown);
   if (previousActiveElement.value) {
     previousActiveElement.value.focus();
   }
@@ -176,7 +230,7 @@ const { t } = useI18n();
   <div>
   <dialog 
     ref="myModal" 
-    :key="app._openCount"
+    :key="props.app._openCount"
     class="modal fixed inset-0 flex items-center justify-center p-2 sm:p-4 overflow-auto" 
     @click.self="closeModal"
     @close="handleDialogClose"
@@ -195,6 +249,34 @@ const { t } = useI18n();
     >
       {{ t('appModal.linkCopied') || 'Link copied!' }}
     </div>
+
+    <!-- Previous app -->
+    <button
+      type="button"
+      data-testid="modal-prev"
+      class="absolute left-2 sm:left-3 top-1/2 -translate-y-1/2 z-20 bg-base-200 hover:bg-base-300 disabled:opacity-30 disabled:cursor-not-allowed rounded-full p-2 shadow-md"
+      :disabled="!hasPrevious"
+      :aria-label="t('appModal.previousApp')"
+      @click="goToPrevious"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+      </svg>
+    </button>
+
+    <!-- Next app -->
+    <button
+      type="button"
+      data-testid="modal-next"
+      class="absolute right-2 sm:right-3 top-1/2 -translate-y-1/2 z-20 bg-base-200 hover:bg-base-300 disabled:opacity-30 disabled:cursor-not-allowed rounded-full p-2 shadow-md"
+      :disabled="!hasNext"
+      :aria-label="t('appModal.nextApp')"
+      @click="goToNext"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+      </svg>
+    </button>
 
     <!-- Botão de fechar -->
     <button

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -72,7 +72,10 @@
     "selfHostingLabel": "Self-hosting difficulty",
     "selfHostingTooltip": "How difficult it is to self-host this app (1=Easy, 3=Advanced)",
     "reasonToUse": "Why use it",
-    "challenges": "Challenges"
+    "challenges": "Challenges",
+    "previousApp": "Previous app",
+    "nextApp": "Next app",
+    "details": "Details for {name}"
   },
   "surpriseMe": {
     "button": "Surprise me!"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -72,7 +72,10 @@
     "selfHostingLabel": "Dificultad de auto-hospedaje",
     "selfHostingTooltip": "Qué tan difícil es auto-hospedar esta app (1=Fácil, 3=Avanzado)",
     "reasonToUse": "Por qué usarlo",
-    "challenges": "Desafíos"
+    "challenges": "Desafíos",
+    "previousApp": "App anterior",
+    "nextApp": "Siguiente app",
+    "details": "Detalles de {name}"
   },
   "surpriseMe": {
     "button": "¡Sorpréndeme!"

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -72,7 +72,10 @@
     "selfHostingLabel": "Dificuldade de auto-hospedagem",
     "selfHostingTooltip": "Quão difícil é auto-hospedar este app (1=Fácil, 3=Avançado)",
     "reasonToUse": "Por que usar",
-    "challenges": "Desafios"
+    "challenges": "Desafios",
+    "previousApp": "App anterior",
+    "nextApp": "Próximo app",
+    "details": "Detalhes de {name}"
   },
   "surpriseMe": {
     "button": "Me surpreenda!"

--- a/src/utils/modalNavigation.spec.ts
+++ b/src/utils/modalNavigation.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import {
+  findAppIndex,
+  getPreviousApp,
+  getNextApp,
+  canGoPrevious,
+  canGoNext,
+} from './modalNavigation';
+import type { App } from '@/types';
+
+function stubApp(name: string): App {
+  return {
+    name,
+    description: '',
+    longDescription: '',
+    features: [],
+    categories: ['social'],
+    alternatives: [],
+    protocol: [],
+    links: [],
+    banner: { src: '', alt: '' },
+  } as App;
+}
+
+const apps = [stubApp('Alpha'), stubApp('Beta'), stubApp('Gamma')];
+
+describe('modalNavigation', () => {
+  it('findAppIndex returns the correct position by name', () => {
+    expect(findAppIndex(apps, 'Beta')).toBe(1);
+    expect(findAppIndex(apps, 'Missing')).toBe(-1);
+    expect(findAppIndex([], 'Alpha')).toBe(-1);
+    expect(findAppIndex(apps, undefined)).toBe(-1);
+  });
+
+  it('getPreviousApp walks backward through the filtered list', () => {
+    expect(getPreviousApp(apps, 'Beta')?.name).toBe('Alpha');
+    expect(getPreviousApp(apps, 'Alpha')).toBeNull();
+    expect(getPreviousApp(apps, 'Missing')).toBeNull();
+  });
+
+  it('getNextApp walks forward through the filtered list', () => {
+    expect(getNextApp(apps, 'Beta')?.name).toBe('Gamma');
+    expect(getNextApp(apps, 'Gamma')).toBeNull();
+    expect(getNextApp(apps, 'Missing')).toBeNull();
+  });
+
+  it('canGoPrevious / canGoNext reflect boundaries', () => {
+    expect(canGoPrevious(apps, 'Beta')).toBe(true);
+    expect(canGoPrevious(apps, 'Alpha')).toBe(false);
+    expect(canGoNext(apps, 'Beta')).toBe(true);
+    expect(canGoNext(apps, 'Gamma')).toBe(false);
+  });
+
+  it('respects a filtered subset (only visible apps)', () => {
+    const filtered = [apps[0], apps[2]]; // Alpha, Gamma only
+    expect(getNextApp(filtered, 'Alpha')?.name).toBe('Gamma');
+    expect(getPreviousApp(filtered, 'Gamma')?.name).toBe('Alpha');
+    expect(getNextApp(filtered, 'Gamma')).toBeNull();
+  });
+});

--- a/src/utils/modalNavigation.ts
+++ b/src/utils/modalNavigation.ts
@@ -1,0 +1,29 @@
+import type { App } from '@/types';
+
+/** Resolve the current app's index within the visible/filtered list by name. */
+export function findAppIndex(apps: App[], currentName: string | undefined): number {
+  if (!currentName || !apps.length) return -1;
+  return apps.findIndex((app) => app.name === currentName);
+}
+
+/** Previous app in the list, or null when at the start / not found. */
+export function getPreviousApp(apps: App[], currentName: string | undefined): App | null {
+  const index = findAppIndex(apps, currentName);
+  if (index <= 0) return null;
+  return apps[index - 1] ?? null;
+}
+
+/** Next app in the list, or null when at the end / not found. */
+export function getNextApp(apps: App[], currentName: string | undefined): App | null {
+  const index = findAppIndex(apps, currentName);
+  if (index < 0 || index >= apps.length - 1) return null;
+  return apps[index + 1] ?? null;
+}
+
+export function canGoPrevious(apps: App[], currentName: string | undefined): boolean {
+  return getPreviousApp(apps, currentName) !== null;
+}
+
+export function canGoNext(apps: App[], currentName: string | undefined): boolean {
+  return getNextApp(apps, currentName) !== null;
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -110,6 +110,12 @@ function handleFecharModal() {
   router.replace({ query: rest });
 }
 
+/** Navigate to another app while the modal stays open (prev/next arrows). */
+function handleNavigateModal(app: App) {
+  modalData.value = { ...app };
+  router.replace({ query: { ...route.query, app: getAppSlug(app) } });
+}
+
 watch(
   () => route.query.app,
   (appSlug) => {
@@ -212,6 +218,12 @@ watch([searchQuery, selectedCategory], ([query, category]) => {
     class="grid grid-cols-1 w-full max-w-full md:grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-12 mt-2"
   >
     <AppCard v-for="app in filteredApps" :key="app.name" :app="app" @abrir="handleAbrirModal" />
-    <AppModal :abrir="mostrarModal" :app="modalData" @atualizarAbrir="handleFecharModal" />
+    <AppModal
+      :abrir="mostrarModal"
+      :app="modalData"
+      :apps="filteredApps"
+      @atualizarAbrir="handleFecharModal"
+      @navigate="handleNavigateModal"
+    />
   </section>
 </template>


### PR DESCRIPTION
## Summary
- Adds left/right navigation arrows inside the app modal so users can browse the currently filtered/search result list without closing the modal.
- Supports keyboard navigation (ArrowLeft / ArrowRight).
- Disables arrows at list boundaries; URL `?app=` query stays in sync on navigate.

## Test plan
- [x] Unit tests for `modalNavigation` helpers (`npm run test:unit -- --run`)
- [x] Local build (`npm run build-only`)
- [x] Headless browser: open modal, click next/prev, keyboard left/right, verify title + URL change
- [ ] CI deploy + live site verification

Closes #77