### PR TITLE
fix: unblock CI build (AppSearch timer type)

### DIFF
--- a/src/components/form/AppSearch.vue
+++ b/src/components/form/AppSearch.vue
@@ -15,7 +15,7 @@ const emit = defineEmits<{
 
 const activeIndex = ref(-1);
 const showSuggestions = ref(false);
-const searchTimeout = ref<number | null>(null);
+const searchTimeout = ref<ReturnType<typeof setTimeout> | null>(null);
 
 // Atualiza o input e aplica debounce
 function onInput(event: Event) {


### PR DESCRIPTION
## Summary
- Fixes pre-existing TS2322 in `AppSearch.vue` that caused the Deploy to VM workflow to fail after #143.

## Test plan
- [x] `npm run build` locally
- [ ] CI deploy succeeds