### PR TITLE
fix(ui): improve modal interface desktop/mobile (#58)

### DIFF
--- a/src/components/AppModal.vue
+++ b/src/components/AppModal.vue
@@ -231,204 +231,172 @@ const { t } = useI18n();
   <dialog 
     ref="myModal" 
     :key="props.app._openCount"
-    class="modal fixed inset-0 flex items-center justify-center p-2 sm:p-4 overflow-auto" 
+    class="modal fixed inset-0 flex items-end sm:items-center justify-center p-0 sm:p-4 overflow-hidden"
     @click.self="closeModal"
     @close="handleDialogClose"
     role="dialog"
     :aria-label="t('appModal.details', { name: localApp.name })"
     aria-modal="true"
   >
-  <div v-if="visible" class="modal-box w-full max-w-[880px] max-h-[calc(100vh-2rem)] overflow-y-auto rounded-xl relative bg-base-100 sm:px-6 sm:py-6 box-border">
-    <!-- Toast -->
+  <div
+    v-if="visible"
+    data-testid="app-modal-box"
+    class="modal-box relative flex flex-col w-full max-w-[880px]
+      h-[min(100dvh,100vh)] sm:h-auto sm:max-h-[min(90dvh,calc(100vh-2rem))]
+      m-0 sm:m-auto rounded-t-2xl sm:rounded-2xl
+      bg-base-100 text-base-content shadow-2xl
+      p-0 overflow-hidden box-border"
+  >
+    <!-- Sticky chrome: close always visible (light + dark) -->
     <div
-      v-if="shareToast"
-      class="absolute bottom-4 left-1/2 -translate-x-1/2 bg-base-200 text-base-content px-4 py-2 rounded shadow-lg z-50"
-      style="pointer-events: none;"
-      role="status"
-      aria-live="polite"
+      class="sticky top-0 z-30 flex items-center justify-end gap-2
+        px-3 py-2 sm:px-4 sm:py-3
+        bg-base-100/95 backdrop-blur-sm border-b border-base-200"
     >
-      {{ t('appModal.linkCopied') || 'Link copied!' }}
+      <button
+        type="button"
+        data-testid="modal-close"
+        class="btn btn-sm btn-circle border border-base-300 bg-base-200 text-base-content
+          hover:bg-base-300 shadow-sm shrink-0"
+        @click="closeModal"
+        :aria-label="t('appModal.close')"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
     </div>
 
-    <!-- Previous app -->
-    <button
-      type="button"
-      data-testid="modal-prev"
-      class="absolute left-2 sm:left-3 top-1/2 -translate-y-1/2 z-20 bg-base-200 hover:bg-base-300 disabled:opacity-30 disabled:cursor-not-allowed rounded-full p-2 shadow-md"
-      :disabled="!hasPrevious"
-      :aria-label="t('appModal.previousApp')"
-      @click="goToPrevious"
-    >
-      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
-      </svg>
-    </button>
-
-    <!-- Next app -->
-    <button
-      type="button"
-      data-testid="modal-next"
-      class="absolute right-2 sm:right-3 top-1/2 -translate-y-1/2 z-20 bg-base-200 hover:bg-base-300 disabled:opacity-30 disabled:cursor-not-allowed rounded-full p-2 shadow-md"
-      :disabled="!hasNext"
-      :aria-label="t('appModal.nextApp')"
-      @click="goToNext"
-    >
-      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-      </svg>
-    </button>
-
-    <!-- Botão de fechar -->
-    <button
-      type="button"
-      class="absolute top-4 right-4 z-20 bg-base-200 hover:bg-base-300 rounded-full p-2 shadow-md"
-      @click="closeModal"
-      :aria-label="t('appModal.close')"
-    >
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        class="h-5 w-5 stroke-current"
-        fill="currentColor"
-        viewBox="0 0 24 24"
-        aria-hidden="true"
+    <!-- Scrollable body -->
+    <div class="flex-1 min-h-0 overflow-y-auto overscroll-contain px-4 pb-6 pt-2 sm:px-8 sm:pb-8 sm:pt-3">
+      <!-- Toast -->
+      <div
+        v-if="shareToast"
+        class="fixed sm:absolute bottom-20 sm:bottom-6 left-1/2 -translate-x-1/2
+          bg-base-200 text-base-content px-4 py-2 rounded-lg shadow-lg z-50 border border-base-300"
+        style="pointer-events: none;"
+        role="status"
+        aria-live="polite"
       >
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          d="M6 18L18 6M6 6l12 12"
-        />
-      </svg>
-    </button>
+        {{ t('appModal.linkCopied') || 'Link copied!' }}
+      </div>
 
-      
       <!-- Banner -->
-      <div class="px-6 sm:px-10 
-        mb-2  sm:mb-4 
-        mt-0 sm:mt-2 md:mt-4"
-      >
+      <div class="mb-4 sm:mb-5 px-2 sm:px-6">
         <img
           :src="bannerErrored ? localApp.banner?.src : localApp.modalBanner?.src || localApp.banner?.src"
           :alt="bannerErrored ? localApp.banner?.alt : localApp.modalBanner?.alt || localApp.banner?.alt"
           @error="bannerErrored = true"
-          class="mx-auto w-full max-w-lg max-h-[120px] object-contain mb-2"
+          class="mx-auto w-full max-w-md max-h-[100px] sm:max-h-[120px] object-contain"
         />
       </div>
 
-      <!-- Texto e conteúdos -->
-      <div class="w-full flex flex-col md:px-4 lg:px-6">
-        <!-- App title with badge -->
-        <div class="flex items-center gap-3 mb-2">
-          <h3 class="text-xl font-bold">{{ localApp.name }}</h3>
+      <!-- Title + badge -->
+      <header class="mb-3 sm:mb-4 pr-1">
+        <div class="flex flex-wrap items-center gap-2 sm:gap-3">
+          <h3 class="text-xl sm:text-2xl font-bold leading-tight text-base-content">{{ localApp.name }}</h3>
           <div
             v-if="localApp.recommendedForBeginners"
             class="badge badge-success badge-sm text-xs font-medium
-                   bg-green-600 dark:bg-green-500 text-white border-none"
+              bg-green-600 dark:bg-green-500 text-white border-none shrink-0"
             :title="t('appModal.goodFirstApp')"
           >
             {{ t('appModal.goodFirstApp') }}
           </div>
         </div>
-        <div
-          class="mb-4 rounded-lg px-3 sm:px-4 py-1 sm:mt-3 text-sm sm:text-base leading-relaxed transition-all duration-300"
-          :class="[
-            'text-base',
-            expandido ? '' : 'line-clamp-2 overflow-hidden',
-            'bg-[var(--color-modal-description)]'
-          ]"
-          tabindex="0"
-          role="button"
-          :aria-expanded="expandido"
-          :aria-label="t('accessibility.toggleDescription')"
-          @click="expandido = !expandido"
-          @keydown.enter="expandido = !expandido"
-          @keydown.space.prevent="expandido = !expandido"
-        >
-          {{ localApp.longDescription }}
-        </div>
+      </header>
 
-        <!-- Features -->
-        <ul v-if="localApp.features?.length" class="list-disc text-sm sm:text-base space-y-2 list-inside mb-4">
-          <li v-for="(feature, index) in localApp.features" :key="index">{{ feature }}</li>
+      <!-- Description -->
+      <div
+        class="mb-5 rounded-xl px-3.5 py-3 sm:px-4 sm:py-3.5 text-sm sm:text-base leading-relaxed
+          transition-all duration-300 cursor-pointer
+          bg-[var(--color-modal-description)] text-base-content"
+        :class="expandido ? '' : 'line-clamp-3 sm:line-clamp-2 overflow-hidden'"
+        tabindex="0"
+        role="button"
+        :aria-expanded="expandido"
+        :aria-label="t('accessibility.toggleDescription')"
+        @click="expandido = !expandido"
+        @keydown.enter="expandido = !expandido"
+        @keydown.space.prevent="expandido = !expandido"
+      >
+        {{ localApp.longDescription }}
+      </div>
+
+      <!-- Content sections with consistent vertical rhythm -->
+      <div class="flex flex-col gap-5 sm:gap-6">
+        <ul v-if="localApp.features?.length" class="list-disc text-sm sm:text-base space-y-2 list-inside marker:text-primary/70">
+          <li v-for="(feature, index) in localApp.features" :key="index" class="pl-0.5">{{ feature }}</li>
         </ul>
 
-        <!-- Reason to Use -->
-        <div v-if="localApp.reasonToUse" class="mb-4">
-          <h4 class="sm:text-lg font-semibold mb-2">{{ t('appModal.reasonToUse') }}</h4>
-          <p class="text-sm sm:text-base leading-relaxed">{{ localApp.reasonToUse }}</p>
-        </div>
+        <section v-if="localApp.reasonToUse">
+          <h4 class="text-base sm:text-lg font-semibold mb-2 text-base-content">{{ t('appModal.reasonToUse') }}</h4>
+          <p class="text-sm sm:text-base leading-relaxed text-base-content/90">{{ localApp.reasonToUse }}</p>
+        </section>
 
-        <!-- Challenges -->
-        <div v-if="localApp.challenges?.length" class="mb-4">
-          <h4 class="sm:text-lg font-semibold mb-2">{{ t('appModal.challenges') }}</h4>
-          <ul class="list-disc text-sm sm:text-base space-y-2 list-inside">
+        <section v-if="localApp.challenges?.length">
+          <h4 class="text-base sm:text-lg font-semibold mb-2 text-base-content">{{ t('appModal.challenges') }}</h4>
+          <ul class="list-disc text-sm sm:text-base space-y-2 list-inside marker:text-primary/70">
             <li v-for="(challenge, index) in localApp.challenges" :key="index">{{ challenge }}</li>
           </ul>
-        </div>
+        </section>
 
-        <div class="mt-2">
-          <div class="flex flex-wrap items-start justify-between gap-4">
-            <div>
-              <h4 v-if="localApp.protocol?.length" class="sm:text-lg font-semibold mb-2">{{ t('appModal.protocols') }}</h4>
-              <div class="flex flex-wrap gap-2">
-                <a
-                  v-for="proto in protocolInfos"
-                  :key="proto.alt"
-                  :href="proto.url"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="hover:opacity-80 transition-opacity"
-                >
-                  <img
-                    :src="proto.src"
-                    :alt="proto.alt"
-                    class="h-6 object-contain"
-                    :title="proto.alt"
-                  />
-                </a>
-              </div>
-            </div>
-
-            <!-- Botões -->
-            <div v-if="favicons.length" class="flex gap-2 py-2 flex-wrap justify-start">
+        <!-- Protocols + actions: stack on mobile, side-by-side on larger screens -->
+        <div class="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between lg:gap-8">
+          <section v-if="localApp.protocol?.length" class="min-w-0">
+            <h4 class="text-base sm:text-lg font-semibold mb-2.5">{{ t('appModal.protocols') }}</h4>
+            <div class="flex flex-wrap gap-2.5">
               <a
-                v-for="(link, index) in favicons"
-                :key="index"
-                :href="link.url"
-                class="btn btn-outline btn-sm flex items-center gap-2 xs:text-sm sm:text-sm"
-                target="_blank" rel="noopener noreferrer"
+                v-for="proto in protocolInfos"
+                :key="proto.alt"
+                :href="proto.url"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="inline-flex items-center rounded-lg border border-base-300 bg-base-200/50 p-1.5 hover:opacity-80 transition-opacity"
               >
-                <img
-                  v-if="link.faviconVisible"
-                  :src="link.faviconSrc"
-                  class="w-4 h-4"
-                  @error="link.faviconError"
-                  alt=""
-                />
-                <img
-                  v-if="link.url.includes('sovereinia.org')"
-                  src="/br-flag.svg"
-                  :alt="t('appModal.br')"
-                  class="w-4 h-4"
-                />
-                {{ link.label }}
+                <img :src="proto.src" :alt="proto.alt" class="h-6 object-contain" :title="proto.alt" />
               </a>
-              <!-- Share Button -->
-              <button
-                type="button"
-                class="btn btn-outline btn-sm flex items-center gap-2"
-                @click="shareApp"
-              >
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 8a3 3 0 11-6 0 3 3 0 016 0zm6 8a6 6 0 10-12 0 6 6 0 0012 0zm-6-6v6" />
-                </svg>{{ t('appModal.share') || 'Share' }}
-              </button>
             </div>
+          </section>
+
+          <div v-if="favicons.length" class="flex flex-wrap gap-2 content-start">
+            <a
+              v-for="(link, index) in favicons"
+              :key="index"
+              :href="link.url"
+              class="btn btn-outline btn-sm h-auto min-h-9 py-1.5 flex items-center gap-2 whitespace-normal text-left"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <img
+                v-if="link.faviconVisible"
+                :src="link.faviconSrc"
+                class="w-4 h-4 shrink-0"
+                @error="link.faviconError"
+                alt=""
+              />
+              <img
+                v-if="link.url.includes('sovereinia.org')"
+                src="/br-flag.svg"
+                :alt="t('appModal.br')"
+                class="w-4 h-4 shrink-0"
+              />
+              <span>{{ link.label }}</span>
+            </a>
+            <button type="button" class="btn btn-outline btn-sm h-auto min-h-9 py-1.5 flex items-center gap-2" @click="shareApp">
+              <svg class="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 8a3 3 0 11-6 0 3 3 0 016 0zm6 8a6 6 0 10-12 0 6 6 0 0012 0zm-6-6v6" />
+              </svg>
+              {{ t('appModal.share') || 'Share' }}
+            </button>
           </div>
         </div>
 
-        <div v-if="localApp.selfHostingLevel" class="mt-4 flex items-center gap-2">
-          <span class="font-semibold" :title="t('appModal.selfHostingTooltip') || 'Self-hosting difficulty'">
+        <div
+          v-if="localApp.selfHostingLevel"
+          class="flex flex-wrap items-center gap-2 rounded-lg border border-base-200 bg-base-200/40 px-3 py-2"
+        >
+          <span class="text-sm sm:text-base font-semibold" :title="t('appModal.selfHostingTooltip') || 'Self-hosting difficulty'">
             {{ t('appModal.selfHostingLabel') || 'Self-hosting difficulty:' }}
           </span>
           <span
@@ -439,27 +407,64 @@ const { t } = useI18n();
               'text-red-500'
             ]"
           >
-            <template v-for="n in 3">
-              <span v-if="n <= localApp.selfHostingLevel">⭐</span>
+            <template v-for="n in 3" :key="n">
+              <span v-if="n <= (localApp.selfHostingLevel || 0)">⭐</span>
               <span v-else>◽️</span>
             </template>
           </span>
         </div>
-        <div v-if="localApp.alternatives?.length" class="mt-4">
-          <h4 class="sm:text-lg font-semibold mb-2" id="alternatives-heading">{{ t('appModal.alternatives') }}</h4>
-          <div class="flex flex-wrap gap-2" role="list" aria-labelledby="alternatives-heading">
-            <span v-for="(alt, index) in localApp.alternatives" :key="alt" role="listitem">
+
+        <section v-if="localApp.alternatives?.length" class="pb-2">
+          <h4 class="text-base sm:text-lg font-semibold mb-2.5" id="alternatives-heading">{{ t('appModal.alternatives') }}</h4>
+          <div class="flex flex-wrap gap-2.5" role="list" aria-labelledby="alternatives-heading">
+            <span v-for="alt in localApp.alternatives" :key="alt" role="listitem">
               <img
                 v-if="visibleAlternatives[alt]"
                 :src="getAlternativeIcon(alt)"
                 :alt="t('accessibility.alternativeApp', { name: alt })"
                 :title="alt"
-                class="w-12 h-12 rounded-full object-contain border border-gray-500"
+                class="w-11 h-11 sm:w-12 sm:h-12 rounded-full object-contain border border-base-300 bg-base-200/30"
                 @error="visibleAlternatives[alt] = false"
               />
             </span>
           </div>
-        </div>
+        </section>
+      </div>
+    </div>
+
+    <!-- Prev / next: footer on small screens, side rails on sm+ -->
+    <div
+      class="sticky bottom-0 z-30 flex items-center justify-between gap-3
+        px-3 py-2.5 sm:px-4 border-t border-base-200 bg-base-100/95 backdrop-blur-sm
+        pb-[max(0.625rem,env(safe-area-inset-bottom))]"
+    >
+      <button
+        type="button"
+        data-testid="modal-prev"
+        class="btn btn-sm btn-circle sm:btn-md border border-base-300 bg-base-200 text-base-content
+          hover:bg-base-300 disabled:opacity-35 disabled:cursor-not-allowed shadow-sm"
+        :disabled="!hasPrevious"
+        :aria-label="t('appModal.previousApp')"
+        @click="goToPrevious"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+        </svg>
+      </button>
+      <span class="text-xs sm:text-sm text-base-content/60 truncate px-1 max-w-[50%] text-center">{{ localApp.name }}</span>
+      <button
+        type="button"
+        data-testid="modal-next"
+        class="btn btn-sm btn-circle sm:btn-md border border-base-300 bg-base-200 text-base-content
+          hover:bg-base-300 disabled:opacity-35 disabled:cursor-not-allowed shadow-sm"
+        :disabled="!hasNext"
+        :aria-label="t('appModal.nextApp')"
+        @click="goToNext"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+        </svg>
+      </button>
     </div>
   </div>
 </dialog>


### PR DESCRIPTION
## Summary
- Improves `AppModal` hierarchy, spacing, and scroll behavior (issue #58).
- Sticky close bar (readable in light/dark), safer mobile full-height sheet, footer prev/next with safe-area padding, clearer action/protocol layout.

## Test plan
- [x] unit + `npm run build`
- [x] headless desktop 1280 + mobile 375: close/prev/next visible, nav works
- [ ] CI deploy + live retest

Closes #58