### PR TITLE
perf: improve initial load (async modal + chunks) (#64)

### DIFF
--- a/src/components/AppCard.vue
+++ b/src/components/AppCard.vue
@@ -95,6 +95,8 @@ const slicedDescription = computed(() => {
         <img
           :src="app.banner.src"
           :alt="app.banner.alt"
+          loading="lazy"
+          decoding="async"
           class="h-20 sm:w-60 sm:h-40
            object-contain"
         />

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import AppCard from '@/components/AppCard.vue';
-import AppModal from '@/components/AppModal.vue';
 import AppSearch from '@/components/form/AppSearch.vue';
 import CategorySelector from '@/components/form/CategorySelector.vue';
 import UseCaseSelector from '@/components/form/UseCaseSelector.vue';
@@ -14,9 +13,12 @@ import { useHeadersStore } from '@/stores/headers';
 import type { App, CategoryId, UseCaseId } from '@/types';
 import { filterApps, shuffleAppsPurely, sortAppsByLinksThenRandom } from '@/utils/filter';
 import { getAppSlug } from '@/utils/global';
-import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
+import { computed, defineAsyncComponent, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
+
+/** Modal is large and rarely needed on first paint — load on demand (issue #64). */
+const AppModal = defineAsyncComponent(() => import('@/components/AppModal.vue'));
 
 const { t } = useI18n();
 const headersStore = useHeadersStore();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,23 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
+  build: {
+    // Split framework/vendor so first paint downloads less JS up front (#64).
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (!id.includes('node_modules')) return;
+          if (id.includes('vue') || id.includes('pinia') || id.includes('vue-router') || id.includes('vue-i18n')) {
+            return 'vue-vendor';
+          }
+          if (id.includes('daisyui') || id.includes('tailwind')) {
+            return 'ui-vendor';
+          }
+        },
+      },
+    },
+    chunkSizeWarningLimit: 600,
+  },
   server: {
     allowedHosts: ['sovereinia.org'],
   },


### PR DESCRIPTION
## Summary
- `defineAsyncComponent` for `AppModal` (issue #64)
- Vite `manualChunks` for vue vendor; modal ships as separate chunk
- `loading=\"lazy\"` on card banners

Main entry JS ~352KB (was ~514KB monolithic) with modal/vendor split in `dist/assets/`.

Closes #64