### PR TITLE
feat: recent viewed apps + keyboard shortcuts help

### DIFF
--- a/src/components/ShortcutsHelp.vue
+++ b/src/components/ShortcutsHelp.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+
+defineProps<{ open: boolean }>();
+const emit = defineEmits<{ close: [] }>();
+const { t } = useI18n();
+
+const rows = [
+  { keys: '/', labelKey: 'shortcuts.search' },
+  { keys: '←', labelKey: 'shortcuts.modalPrev' },
+  { keys: '→', labelKey: 'shortcuts.modalNext' },
+  { keys: 'Esc', labelKey: 'shortcuts.escape' },
+  { keys: '?', labelKey: 'shortcuts.title' },
+];
+</script>
+
+<template>
+  <div
+    v-if="open"
+    class="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/40"
+    data-testid="shortcuts-overlay"
+    role="dialog"
+    aria-modal="true"
+    :aria-label="t('shortcuts.title')"
+    @click.self="emit('close')"
+  >
+    <div class="bg-base-100 text-base-content rounded-2xl shadow-xl max-w-md w-full p-5 border border-base-300">
+      <div class="flex justify-between items-center mb-3">
+        <h2 class="text-lg font-semibold">{{ t('shortcuts.title') }}</h2>
+        <button type="button" class="btn btn-ghost btn-sm" :aria-label="t('shortcuts.close')" @click="emit('close')">✕</button>
+      </div>
+      <ul class="space-y-2 text-sm">
+        <li v-for="row in rows" :key="row.labelKey" class="flex justify-between gap-4 border-b border-base-200 py-1.5">
+          <kbd class="font-mono bg-base-200 px-2 py-0.5 rounded">{{ row.keys }}</kbd>
+          <span class="text-right text-base-content/80">{{ t(row.labelKey) }}</span>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1260,5 +1260,19 @@
     "opt_yes_fed": "Yes, federation matters",
     "opt_no_fed": "Not important",
     "results": "Suggested apps"
+  },
+  "recent": {
+    "title": "Recently viewed",
+    "empty": "Open an app to build this list",
+    "clear": "Clear recent"
+  },
+  "shortcuts": {
+    "title": "Keyboard shortcuts",
+    "open": "Shortcuts",
+    "close": "Close",
+    "search": "Focus search",
+    "modalPrev": "Previous app in modal",
+    "modalNext": "Next app in modal",
+    "escape": "Close modal / clear search"
   }
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1260,5 +1260,19 @@
     "opt_yes_fed": "Sí, la federación importa",
     "opt_no_fed": "No es prioritario",
     "results": "Apps sugeridas"
+  },
+  "recent": {
+    "title": "Vistos recientemente",
+    "empty": "Abre una app para armar esta lista",
+    "clear": "Borrar recientes"
+  },
+  "shortcuts": {
+    "title": "Atajos de teclado",
+    "open": "Atajos",
+    "close": "Cerrar",
+    "search": "Enfocar búsqueda",
+    "modalPrev": "App anterior en el modal",
+    "modalNext": "Siguiente app en el modal",
+    "escape": "Cerrar modal / limpiar búsqueda"
   }
 }

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -1260,5 +1260,19 @@
     "opt_yes_fed": "Sim, federação importa",
     "opt_no_fed": "Não é prioritário",
     "results": "Apps sugeridos"
+  },
+  "recent": {
+    "title": "Vistos recentemente",
+    "empty": "Abra um app para montar esta lista",
+    "clear": "Limpar recentes"
+  },
+  "shortcuts": {
+    "title": "Atalhos de teclado",
+    "open": "Atalhos",
+    "close": "Fechar",
+    "search": "Focar busca",
+    "modalPrev": "App anterior no modal",
+    "modalNext": "Próximo app no modal",
+    "escape": "Fechar modal / limpar busca"
   }
 }

--- a/src/utils/recentApps.spec.ts
+++ b/src/utils/recentApps.spec.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { pushRecentApp, listRecentApps, clearRecentApps, resolveRecentApps } from './recentApps';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('recentApps', () => {
+  it('pushes newest first and dedupes', () => {
+    pushRecentApp('Mastodon');
+    pushRecentApp('PeerTube');
+    pushRecentApp('Mastodon');
+    expect(listRecentApps()).toEqual(['Mastodon', 'PeerTube']);
+  });
+
+  it('caps length and resolves against catalog', () => {
+    for (let i = 0; i < 12; i++) pushRecentApp(`App${i}`);
+    expect(listRecentApps().length).toBe(8);
+    const catalog = [{ name: 'App11' }, { name: 'App10' }, { name: 'Gone' }];
+    const resolved = resolveRecentApps(catalog);
+    expect(resolved.map((a) => a.name)).toEqual(['App11', 'App10']);
+  });
+
+  it('clearRecentApps empties storage', () => {
+    pushRecentApp('X');
+    clearRecentApps();
+    expect(listRecentApps()).toEqual([]);
+  });
+});

--- a/src/utils/recentApps.ts
+++ b/src/utils/recentApps.ts
@@ -1,0 +1,39 @@
+const STORAGE_KEY = 'guia-recent-apps';
+const MAX_RECENT = 8;
+
+function readList(): string[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const arr = JSON.parse(raw) as unknown;
+    return Array.isArray(arr) ? arr.filter((x): x is string => typeof x === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeList(names: string[]) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(names.slice(0, MAX_RECENT)));
+}
+
+/** Record that the user opened an app (by display name). Most recent first. */
+export function pushRecentApp(name: string | undefined): string[] {
+  if (!name?.trim()) return readList();
+  const next = [name, ...readList().filter((n) => n !== name)].slice(0, MAX_RECENT);
+  writeList(next);
+  return next;
+}
+
+export function listRecentApps(): string[] {
+  return readList();
+}
+
+export function clearRecentApps(): void {
+  localStorage.removeItem(STORAGE_KEY);
+}
+
+/** Resolve recent names against the current catalog (drop missing). */
+export function resolveRecentApps<T extends { name: string }>(catalog: T[], names: string[] = listRecentApps()): T[] {
+  const byName = new Map(catalog.map((a) => [a.name, a]));
+  return names.map((n) => byName.get(n)).filter((a): a is T => !!a);
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -6,6 +6,7 @@ import UseCaseSelector from '@/components/form/UseCaseSelector.vue';
 import ReshuffleButton from '@/components/form/ReshuffleButton.vue';
 import SurpriseMeButton from '@/components/form/SurpriseMeButton.vue';
 import RecommendationWizard from '@/components/RecommendationWizard.vue';
+import ShortcutsHelp from '@/components/ShortcutsHelp.vue';
 import { useSEO } from '@/composables/useSEO';
 import { useApps } from '@/data/apps';
 import { categories } from '@/data/categories';
@@ -14,6 +15,12 @@ import { useHeadersStore } from '@/stores/headers';
 import type { App, CategoryId, UseCaseId } from '@/types';
 import { filterApps, shuffleAppsPurely, sortAppsByLinksThenRandom } from '@/utils/filter';
 import { getAppSlug } from '@/utils/global';
+import {
+  clearRecentApps,
+  listRecentApps,
+  pushRecentApp,
+  resolveRecentApps,
+} from '@/utils/recentApps';
 import { computed, defineAsyncComponent, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
@@ -33,8 +40,11 @@ const selectedCategory = ref<CategoryId>('all');
 const selectedUseCase = ref<UseCaseId | 'all'>('all');
 const showFilters = ref(false);
 const showWizard = ref(false);
+const showShortcuts = ref(false);
 const beginnersOnly = ref(false);
 const federatedOnly = ref(false);
+/** Bump when recent list changes so the chip row re-renders. */
+const recentTick = ref(0);
 const route = useRoute();
 const router = useRouter();
 
@@ -63,6 +73,22 @@ const filteredApps = computed(() => {
   }
   return list;
 });
+
+const recentApps = computed(() => {
+  recentTick.value;
+  return resolveRecentApps(apps.value, listRecentApps());
+});
+
+function recordRecent(app: App | Partial<App> | undefined) {
+  if (!app?.name) return;
+  pushRecentApp(app.name);
+  recentTick.value += 1;
+}
+
+function onClearRecent() {
+  clearRecentApps();
+  recentTick.value += 1;
+}
 
 function onWizardApply(payload: {
   useCase: UseCaseId | 'all';
@@ -96,6 +122,44 @@ const searchPlaceholder = computed(() =>
 
 const isUpdatingFromURL = ref(false);
 
+function isTypingTarget(el: EventTarget | null): boolean {
+  if (!(el instanceof HTMLElement)) return false;
+  const tag = el.tagName;
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || el.isContentEditable;
+}
+
+function focusSearchInput() {
+  showFilters.value = true;
+  nextTick(() => {
+    const input = document.querySelector<HTMLInputElement>(
+      '[data-testid="app-search"] input, input[type="search"], header ~ section input',
+    );
+    const fallback = document.querySelector<HTMLInputElement>('input');
+    (input || fallback)?.focus();
+  });
+}
+
+function onGlobalKeydown(e: KeyboardEvent) {
+  if (e.defaultPrevented || e.metaKey || e.ctrlKey || e.altKey) return;
+
+  if (e.key === '?' && !isTypingTarget(e.target)) {
+    e.preventDefault();
+    showShortcuts.value = !showShortcuts.value;
+    return;
+  }
+
+  if (showShortcuts.value && e.key === 'Escape') {
+    e.preventDefault();
+    showShortcuts.value = false;
+    return;
+  }
+
+  if (e.key === '/' && !isTypingTarget(e.target) && !mostrarModal.value && !showShortcuts.value) {
+    e.preventDefault();
+    focusSearchInput();
+  }
+}
+
 onMounted(() => {
   const appSlug = route.query.app;
   if (appSlug) {
@@ -108,6 +172,7 @@ onMounted(() => {
 
 onMounted(() => {
   window.addEventListener('resize', updateWindowWidth);
+  window.addEventListener('keydown', onGlobalKeydown);
 
   updateSEO({
     title: 'Sovereinia | Guia de Apps Descentralizados',
@@ -120,6 +185,7 @@ onMounted(() => {
 
 onUnmounted(() => {
   window.removeEventListener('resize', updateWindowWidth);
+  window.removeEventListener('keydown', onGlobalKeydown);
 });
 
 function handleAbrirModal(app: App) {
@@ -128,6 +194,7 @@ function handleAbrirModal(app: App) {
   nextTick(() => {
     modalData.value = { ...app };
     mostrarModal.value = true;
+    recordRecent(app);
     router.replace({ query: { ...route.query, app: getAppSlug(app) } });
   });
 }
@@ -146,6 +213,7 @@ function handleFecharModal() {
 /** Navigate to another app while the modal stays open (prev/next arrows). */
 function handleNavigateModal(app: App) {
   modalData.value = { ...app };
+  recordRecent(app);
   router.replace({ query: { ...route.query, app: getAppSlug(app) } });
 }
 
@@ -160,6 +228,7 @@ watch(
         nextTick(() => {
           modalData.value = { ...found };
           mostrarModal.value = true;
+          recordRecent(found);
           isUpdatingFromURL.value = false;
         });
       }
@@ -226,7 +295,7 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
   </header>
 
   <section class="w-full space-y-5">
-    <div class="flex justify-center">
+    <div class="flex justify-center gap-2 flex-wrap">
       <button
         type="button"
         class="btn btn-outline btn-sm"
@@ -234,6 +303,16 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
         @click="showWizard = !showWizard"
       >
         {{ t('wizard.open') }}
+      </button>
+      <button
+        type="button"
+        class="btn btn-ghost btn-sm"
+        data-testid="open-shortcuts"
+        :aria-label="t('shortcuts.open')"
+        @click="showShortcuts = true"
+      >
+        {{ t('shortcuts.open') }}
+        <kbd class="ml-1 opacity-60 font-mono text-xs">?</kbd>
       </button>
     </div>
     <RecommendationWizard
@@ -261,6 +340,39 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
         />
         <ReshuffleButton />
       </div>
+    </div>
+  </section>
+
+  <section
+    v-if="recentApps.length > 0"
+    class="mb-4"
+    data-testid="recent-apps"
+    aria-labelledby="recent-apps-heading"
+  >
+    <div class="flex items-center justify-between gap-2 mb-2 px-1">
+      <h2 id="recent-apps-heading" class="text-sm font-semibold text-base-content/80">
+        {{ t('recent.title') }}
+      </h2>
+      <button
+        type="button"
+        class="btn btn-ghost btn-xs"
+        data-testid="clear-recent"
+        @click="onClearRecent"
+      >
+        {{ t('recent.clear') }}
+      </button>
+    </div>
+    <div class="flex flex-wrap gap-2">
+      <button
+        v-for="app in recentApps"
+        :key="'recent-' + app.name"
+        type="button"
+        class="btn btn-sm btn-outline"
+        :data-testid="'recent-chip-' + app.name"
+        @click="handleAbrirModal(app)"
+      >
+        {{ app.name }}
+      </button>
     </div>
   </section>
 
@@ -296,4 +408,6 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
     @atualizarAbrir="handleFecharModal"
     @navigate="handleNavigateModal"
   />
+
+  <ShortcutsHelp :open="showShortcuts" @close="showShortcuts = false" />
 </template>


### PR DESCRIPTION
## Summary
Agent-invented UX improvements (empty backlog):
- **Recently viewed apps**: opening an app (modal / deep link / surprise / prev-next) records it in `localStorage` (max 8, newest first). Home shows a chip row with clear control (`data-testid="recent-apps"`).
- **Keyboard shortcuts help**: `?` or toolbar button opens overlay (`ShortcutsHelp`); `/` focuses search when not typing in an input; Esc closes the overlay.
- **Safety snapshot**: `snapshots/guia-safety-snapshot-2026-06-24-pre-autonomous.zip` (source + config, no `node_modules`).

## Test plan
- [x] `npm run test:unit -- --run` (includes `recentApps.spec.ts`)
- [x] `npm run build` (type-check + vite)
- [ ] Headless local smoke (screenshots in proofs)
- [ ] Deploy to VM + live retest on https://sovereinia.org/guia/

## Acceptance
Pure logic covered by unit tests; UI has stable testids for recent/shortcuts.