### PR TITLE
feat: quick beginners/federated filter chips + app count

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1261,6 +1261,12 @@
     "opt_no_fed": "Not important",
     "results": "Suggested apps"
   },
+  "filters": {
+    "quickLabel": "Quick filters",
+    "beginners": "Beginner-friendly",
+    "federated": "Federated / protocols",
+    "appCount": "Showing {shown} of {total} apps"
+  },
   "recent": {
     "title": "Recently viewed",
     "empty": "Open an app to build this list",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1261,6 +1261,12 @@
     "opt_no_fed": "No es prioritario",
     "results": "Apps sugeridas"
   },
+  "filters": {
+    "quickLabel": "Filtros rápidos",
+    "beginners": "Para principiantes",
+    "federated": "Federados / protocolos",
+    "appCount": "Mostrando {shown} de {total} apps"
+  },
   "recent": {
     "title": "Vistos recientemente",
     "empty": "Abre una app para armar esta lista",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -1261,6 +1261,12 @@
     "opt_no_fed": "Não é prioritário",
     "results": "Apps sugeridos"
   },
+  "filters": {
+    "quickLabel": "Filtros rápidos",
+    "beginners": "Para iniciantes",
+    "federated": "Federados / protocolos",
+    "appCount": "Mostrando {shown} de {total} apps"
+  },
   "recent": {
     "title": "Vistos recentemente",
     "empty": "Abra um app para montar esta lista",

--- a/src/utils/quickFilters.spec.ts
+++ b/src/utils/quickFilters.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { applyQuickFilters, isBeginnerApp, isFederatedApp } from './quickFilters';
+import type { App } from '@/types';
+
+function app(partial: Partial<App> & { name: string }): App {
+  return {
+    description: '',
+    categories: [],
+    ...partial,
+  } as App;
+}
+
+describe('quickFilters', () => {
+  it('detects beginners and federated flags', () => {
+    expect(isBeginnerApp(app({ name: 'A', recommendedForBeginners: true }))).toBe(true);
+    expect(isBeginnerApp(app({ name: 'B' }))).toBe(false);
+    expect(isFederatedApp(app({ name: 'C', protocol: ['ActivityPub'] }))).toBe(true);
+    expect(isFederatedApp(app({ name: 'D', categories: ['protocols'] }))).toBe(true);
+    expect(isFederatedApp(app({ name: 'E', useCases: ['protocol'] }))).toBe(true);
+    expect(isFederatedApp(app({ name: 'F', categories: ['social'] }))).toBe(false);
+  });
+
+  it('applyQuickFilters combines toggles', () => {
+    const catalog = [
+      app({ name: 'BegFed', recommendedForBeginners: true, protocol: ['AP'] }),
+      app({ name: 'BegOnly', recommendedForBeginners: true }),
+      app({ name: 'FedOnly', protocol: ['AP'] }),
+      app({ name: 'Neither' }),
+    ];
+    expect(applyQuickFilters(catalog, { beginnersOnly: true }).map((a) => a.name)).toEqual([
+      'BegFed',
+      'BegOnly',
+    ]);
+    expect(applyQuickFilters(catalog, { federatedOnly: true }).map((a) => a.name)).toEqual([
+      'BegFed',
+      'FedOnly',
+    ]);
+    expect(
+      applyQuickFilters(catalog, { beginnersOnly: true, federatedOnly: true }).map((a) => a.name),
+    ).toEqual(['BegFed']);
+  });
+});

--- a/src/utils/quickFilters.ts
+++ b/src/utils/quickFilters.ts
@@ -1,0 +1,30 @@
+import type { App } from '@/types';
+
+/** Apps explicitly recommended for beginners (catalog flag). */
+export function isBeginnerApp(app: Pick<App, 'recommendedForBeginners'>): boolean {
+  return !!app.recommendedForBeginners;
+}
+
+/**
+ * Federated / open-protocol apps: has protocol list, protocols category, or protocol use case.
+ * Mirrors HomeView filter behavior so chips and wizard stay consistent.
+ */
+export function isFederatedApp(
+  app: Pick<App, 'protocol' | 'categories' | 'useCases'>,
+): boolean {
+  return (
+    (app.protocol || []).length > 0 ||
+    (app.categories || []).includes('protocols') ||
+    (app.useCases || []).includes('protocol')
+  );
+}
+
+export function applyQuickFilters<T extends App>(
+  list: T[],
+  opts: { beginnersOnly?: boolean; federatedOnly?: boolean },
+): T[] {
+  let out = list;
+  if (opts.beginnersOnly) out = out.filter(isBeginnerApp);
+  if (opts.federatedOnly) out = out.filter(isFederatedApp);
+  return out;
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -15,6 +15,7 @@ import { useHeadersStore } from '@/stores/headers';
 import type { App, CategoryId, UseCaseId } from '@/types';
 import { filterApps, shuffleAppsPurely, sortAppsByLinksThenRandom } from '@/utils/filter';
 import { getAppSlug } from '@/utils/global';
+import { applyQuickFilters } from '@/utils/quickFilters';
 import {
   clearRecentApps,
   listRecentApps,
@@ -59,20 +60,29 @@ const orderedApps = computed(() => {
 });
 
 const filteredApps = computed(() => {
-  let list = filterApps(orderedApps.value, selectedCategory.value, searchQuery.value, selectedUseCase.value);
-  if (beginnersOnly.value) {
-    list = list.filter((a) => a.recommendedForBeginners);
-  }
-  if (federatedOnly.value) {
-    list = list.filter(
-      (a) =>
-        (a.protocol || []).length > 0 ||
-        a.categories.includes('protocols') ||
-        (a.useCases || []).includes('protocol'),
-    );
-  }
-  return list;
+  const list = filterApps(
+    orderedApps.value,
+    selectedCategory.value,
+    searchQuery.value,
+    selectedUseCase.value,
+  );
+  return applyQuickFilters(list, {
+    beginnersOnly: beginnersOnly.value,
+    federatedOnly: federatedOnly.value,
+  });
 });
+
+function toggleBeginnersOnly() {
+  beginnersOnly.value = !beginnersOnly.value;
+  showFilters.value = true;
+  globalStore.resetReshuffle();
+}
+
+function toggleFederatedOnly() {
+  federatedOnly.value = !federatedOnly.value;
+  showFilters.value = true;
+  globalStore.resetReshuffle();
+}
 
 const recentApps = computed(() => {
   recentTick.value;
@@ -292,6 +302,13 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
     <p class="text-center text-base mb-5 px-2">
       {{ subtitleBase }} <span class="font-bold">{{ subtitleSuffix }}</span>
     </p>
+    <p
+      class="text-center text-sm text-base-content/70 mb-3"
+      data-testid="app-count-badge"
+      aria-live="polite"
+    >
+      {{ t('filters.appCount', { shown: filteredApps.length, total: apps.length }) }}
+    </p>
   </header>
 
   <section class="w-full space-y-5">
@@ -313,6 +330,33 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
       >
         {{ t('shortcuts.open') }}
         <kbd class="ml-1 opacity-60 font-mono text-xs">?</kbd>
+      </button>
+    </div>
+    <div
+      class="flex justify-center gap-2 flex-wrap"
+      data-testid="quick-filter-chips"
+      role="group"
+      :aria-label="t('filters.quickLabel')"
+    >
+      <button
+        type="button"
+        class="btn btn-sm"
+        :class="beginnersOnly ? 'btn-primary' : 'btn-outline'"
+        data-testid="chip-beginners"
+        :aria-pressed="beginnersOnly"
+        @click="toggleBeginnersOnly"
+      >
+        {{ t('filters.beginners') }}
+      </button>
+      <button
+        type="button"
+        class="btn btn-sm"
+        :class="federatedOnly ? 'btn-primary' : 'btn-outline'"
+        data-testid="chip-federated"
+        :aria-pressed="federatedOnly"
+        @click="toggleFederatedOnly"
+      >
+        {{ t('filters.federated') }}
       </button>
     </div>
     <RecommendationWizard


### PR DESCRIPTION
## Summary (agent-invented — empty GH backlog)
- **Quick filter chips** always on home: Beginner-friendly + Federated/protocols (`data-testid="quick-filter-chips"`), toggle without opening the recommendation wizard.
- **App count badge** under title: “Showing {shown} of {total} apps” (`data-testid="app-count-badge"`).
- Logic centralized in `src/utils/quickFilters.ts` (used by HomeView; same rules as prior inline filters) + unit tests.

## Acceptance
- Chips visible on first paint; toggling changes grid + count.
- Unit tests cover beginner/federated detection and combined filters.
- i18n keys `filters.*` in en/pt/es.

## Test plan
- [x] `npm run test:unit -- --run`
- [x] `npm run build`
- [ ] Headless local/live after merge