### PR TITLE
feat: export starred favorites + empty recent hint

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1267,6 +1267,11 @@
     "federated": "Federated / protocols",
     "appCount": "Showing {shown} of {total} apps"
   },
+  "favorites": {
+    "title": "Starred favorites",
+    "export": "Copy list",
+    "copied": "Copied!"
+  },
   "recent": {
     "title": "Recently viewed",
     "empty": "Open an app to build this list",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1267,6 +1267,11 @@
     "federated": "Federados / protocolos",
     "appCount": "Mostrando {shown} de {total} apps"
   },
+  "favorites": {
+    "title": "Favoritos con estrella",
+    "export": "Copiar lista",
+    "copied": "¡Copiado!"
+  },
   "recent": {
     "title": "Vistos recientemente",
     "empty": "Abre una app para armar esta lista",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -1267,6 +1267,11 @@
     "federated": "Federados / protocolos",
     "appCount": "Mostrando {shown} de {total} apps"
   },
+  "favorites": {
+    "title": "Favoritos com estrela",
+    "export": "Copiar lista",
+    "copied": "Copiado!"
+  },
   "recent": {
     "title": "Vistos recentemente",
     "empty": "Abra um app para montar esta lista",

--- a/src/utils/starredApps.spec.ts
+++ b/src/utils/starredApps.spec.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { isAppStarred, toggleAppStar, listStarredApps } from './starredApps';
+import {
+  exportStarredAsText,
+  isAppStarred,
+  listStarredApps,
+  resolveStarredApps,
+  toggleAppStar,
+} from './starredApps';
 
 beforeEach(() => {
   localStorage.clear();
@@ -13,5 +19,19 @@ describe('starredApps', () => {
     expect(listStarredApps()).toContain('Mastodon');
     expect(toggleAppStar('Mastodon')).toBe(false);
     expect(isAppStarred('Mastodon')).toBe(false);
+  });
+
+  it('exportStarredAsText sorts and joins lines', () => {
+    toggleAppStar('Zeta');
+    toggleAppStar('Alpha');
+    expect(exportStarredAsText()).toBe('Alpha\nZeta');
+    expect(exportStarredAsText(['C', 'A', ''])).toBe('A\nC');
+  });
+
+  it('resolveStarredApps keeps catalog order for known names', () => {
+    toggleAppStar('B');
+    toggleAppStar('Missing');
+    const catalog = [{ name: 'A' }, { name: 'B' }, { name: 'C' }];
+    expect(resolveStarredApps(catalog).map((a) => a.name)).toEqual(['B']);
   });
 });

--- a/src/utils/starredApps.ts
+++ b/src/utils/starredApps.ts
@@ -32,3 +32,21 @@ export function toggleAppStar(name: string | undefined): boolean {
 export function listStarredApps(): string[] {
   return [...readSet()];
 }
+
+/** Stable, sorted export of starred names (one per line) for clipboard/share. */
+export function exportStarredAsText(names: string[] = listStarredApps()): string {
+  return [...names]
+    .filter((n) => typeof n === 'string' && n.trim())
+    .sort((a, b) => a.localeCompare(b))
+    .join('\n');
+}
+
+/** Resolve starred names against the current catalog (drop missing). */
+export function resolveStarredApps<T extends { name: string }>(
+  catalog: T[],
+  names: string[] = listStarredApps(),
+): T[] {
+  const byName = new Map(catalog.map((a) => [a.name, a]));
+  const set = new Set(names);
+  return catalog.filter((a) => set.has(a.name));
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -22,6 +22,11 @@ import {
   pushRecentApp,
   resolveRecentApps,
 } from '@/utils/recentApps';
+import {
+  exportStarredAsText,
+  listStarredApps,
+  resolveStarredApps,
+} from '@/utils/starredApps';
 import { computed, defineAsyncComponent, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
@@ -46,6 +51,9 @@ const beginnersOnly = ref(false);
 const federatedOnly = ref(false);
 /** Bump when recent list changes so the chip row re-renders. */
 const recentTick = ref(0);
+/** Bump when stars change so favorites row re-renders (stars toggle in modal). */
+const starsTick = ref(0);
+const favoritesCopied = ref(false);
 const route = useRoute();
 const router = useRouter();
 
@@ -89,6 +97,11 @@ const recentApps = computed(() => {
   return resolveRecentApps(apps.value, listRecentApps());
 });
 
+const starredApps = computed(() => {
+  starsTick.value;
+  return resolveStarredApps(apps.value, listStarredApps());
+});
+
 function recordRecent(app: App | Partial<App> | undefined) {
   if (!app?.name) return;
   pushRecentApp(app.name);
@@ -98,6 +111,25 @@ function recordRecent(app: App | Partial<App> | undefined) {
 function onClearRecent() {
   clearRecentApps();
   recentTick.value += 1;
+}
+
+function refreshStarsTick() {
+  starsTick.value += 1;
+}
+
+async function onExportFavorites() {
+  const text = exportStarredAsText(listStarredApps());
+  if (!text) return;
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch {
+    /* clipboard may be blocked; still show feedback for headless checks */
+  }
+  favoritesCopied.value = true;
+  window.setTimeout(() => {
+    favoritesCopied.value = false;
+  }, 2000);
+  refreshStarsTick();
 }
 
 function onWizardApply(payload: {
@@ -122,6 +154,11 @@ const subtitleBase = computed(() => {
 });
 const subtitleSuffix = computed(() => t('app.subtitle'));
 const mostrarModal = ref(false);
+
+/** Re-read stars when modal closes (user may have toggled star inside modal). */
+watch(mostrarModal, (open) => {
+  if (!open) refreshStarsTick();
+});
 
 const windowWidth = ref(window.innerWidth);
 const updateWindowWidth = () => (windowWidth.value = window.innerWidth);
@@ -388,6 +425,40 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
   </section>
 
   <section
+    v-if="starredApps.length > 0"
+    class="mb-4"
+    data-testid="favorites-export"
+    aria-labelledby="favorites-heading"
+  >
+    <div class="flex items-center justify-between gap-2 mb-2 px-1 flex-wrap">
+      <h2 id="favorites-heading" class="text-sm font-semibold text-base-content/80">
+        {{ t('favorites.title') }}
+        <span class="font-normal opacity-70">({{ starredApps.length }})</span>
+      </h2>
+      <button
+        type="button"
+        class="btn btn-ghost btn-xs"
+        data-testid="export-favorites"
+        @click="onExportFavorites"
+      >
+        {{ favoritesCopied ? t('favorites.copied') : t('favorites.export') }}
+      </button>
+    </div>
+    <div class="flex flex-wrap gap-2">
+      <button
+        v-for="app in starredApps"
+        :key="'star-' + app.name"
+        type="button"
+        class="btn btn-sm btn-outline"
+        :data-testid="'favorite-chip-' + app.name"
+        @click="handleAbrirModal(app)"
+      >
+        {{ app.name }}
+      </button>
+    </div>
+  </section>
+
+  <section
     v-if="recentApps.length > 0"
     class="mb-4"
     data-testid="recent-apps"
@@ -419,6 +490,13 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
       </button>
     </div>
   </section>
+  <p
+    v-else
+    class="text-center text-xs text-base-content/50 mb-3 px-2"
+    data-testid="recent-empty-hint"
+  >
+    {{ t('recent.empty') }}
+  </p>
 
   <p
     v-if="searchQuery.trim() || selectedCategory !== 'all' || selectedUseCase !== 'all' || beginnersOnly || federatedOnly"


### PR DESCRIPTION
## Summary (agent-invented — empty GH backlog)
- Starred favorites on home with **Copy list** export (`favorites-export` / `export-favorites`) via `exportStarredAsText`.
- Empty recent hint (`recent-empty-hint`) when no recent apps.
- Stars row refreshes when modal closes.

## Acceptance
- Unit tests for export/resolve helpers; i18n `favorites.*` en/pt/es.