### PR TITLE
feat(a11y): trap Tab focus inside app modal

### DIFF
--- a/src/components/AppModal.vue
+++ b/src/components/AppModal.vue
@@ -5,6 +5,7 @@ import { getProtocolInfo } from '@/utils/global.ts';
 import { getFaviconPath } from '@/utils/global.ts';
 import { getAppSlug } from '@/utils/global.ts';
 import { canGoNext, canGoPrevious, getNextApp, getPreviousApp } from '@/utils/modalNavigation';
+import { trapTabKey } from '@/utils/focusTrap';
 import { isAppStarred, toggleAppStar } from '@/utils/starredApps';
 import type { App } from '@/types';
 import { useI18n } from 'vue-i18n';
@@ -64,6 +65,12 @@ function goToNext() {
 
 function onKeydown(event: KeyboardEvent) {
   if (!props.abrir || !visible.value) return;
+
+  // Keep keyboard focus inside the dialog while open (a11y).
+  if (event.key === 'Tab' && trapTabKey(myModal.value, event)) {
+    return;
+  }
+
   const target = event.target as HTMLElement | null;
   if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) {
     return;

--- a/src/utils/focusTrap.spec.ts
+++ b/src/utils/focusTrap.spec.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { focusTrapIndex } from './focusTrap';
+
+describe('focusTrapIndex', () => {
+  it('wraps forward and backward', () => {
+    expect(focusTrapIndex(3, 0, false)).toBe(1);
+    expect(focusTrapIndex(3, 2, false)).toBe(0);
+    expect(focusTrapIndex(3, 0, true)).toBe(2);
+    expect(focusTrapIndex(3, 2, true)).toBe(1);
+  });
+
+  it('handles empty and unknown current', () => {
+    expect(focusTrapIndex(0, 0, false)).toBe(-1);
+    expect(focusTrapIndex(4, -1, false)).toBe(0);
+    expect(focusTrapIndex(4, -1, true)).toBe(3);
+  });
+});

--- a/src/utils/focusTrap.ts
+++ b/src/utils/focusTrap.ts
@@ -1,0 +1,52 @@
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+/** Visible, non-disabled focusable elements within a root (dialog/modal). */
+export function getFocusableElements(root: ParentNode | null | undefined): HTMLElement[] {
+  if (!root) return [];
+  const nodes = Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+  return nodes.filter((el) => {
+    if (el.hasAttribute('disabled') || el.getAttribute('aria-hidden') === 'true') return false;
+    const style = typeof window !== 'undefined' ? window.getComputedStyle(el) : null;
+    if (style && (style.visibility === 'hidden' || style.display === 'none')) return false;
+    return true;
+  });
+}
+
+/**
+ * Keep Tab / Shift+Tab cycling inside `root`. Returns true if the event was handled.
+ * Pure positioning logic is unit-tested via next focus index helper.
+ */
+export function focusTrapIndex(length: number, currentIndex: number, shiftKey: boolean): number {
+  if (length <= 0) return -1;
+  if (currentIndex < 0) return shiftKey ? length - 1 : 0;
+  if (shiftKey) return currentIndex <= 0 ? length - 1 : currentIndex - 1;
+  return currentIndex >= length - 1 ? 0 : currentIndex + 1;
+}
+
+/** Apply focus trap for a Tab keydown on the given container. */
+export function trapTabKey(root: HTMLElement | null | undefined, event: KeyboardEvent): boolean {
+  if (!root || event.key !== 'Tab') return false;
+  const focusables = getFocusableElements(root);
+  if (focusables.length === 0) return false;
+
+  const active = document.activeElement as HTMLElement | null;
+  let currentIndex = active ? focusables.indexOf(active) : -1;
+  // Focus may be inside a nested node not in the list (e.g. contenteditable child)
+  if (currentIndex < 0 && active && root.contains(active)) {
+    currentIndex = event.shiftKey ? 0 : focusables.length - 1;
+  }
+
+  const nextIndex = focusTrapIndex(focusables.length, currentIndex, event.shiftKey);
+  if (nextIndex < 0) return false;
+
+  const atEdge =
+    (event.shiftKey && (currentIndex <= 0 || !root.contains(active))) ||
+    (!event.shiftKey && (currentIndex < 0 || currentIndex >= focusables.length - 1));
+
+  if (!atEdge && currentIndex >= 0) return false;
+
+  event.preventDefault();
+  focusables[nextIndex]?.focus();
+  return true;
+}


### PR DESCRIPTION
## Summary (agent-invented — empty GH backlog)
- **Focus trap** on open app modal: Tab / Shift+Tab cycles focusable controls inside the dialog instead of escaping to the page behind.
- Pure helpers in `src/utils/focusTrap.ts` (`focusTrapIndex`, `trapTabKey`, `getFocusableElements`) with unit tests for index wrap logic.
- Wires into existing `AppModal` keydown (alongside arrow prev/next).

## Acceptance
- Unit tests pass for `focusTrapIndex` edge cases.
- Modal key handler invokes trap on `Tab` when dialog is open.
- Build/type-check clean.