### PR TITLE
feat: centralize locale preference + html lang

### DIFF
--- a/src/components/LanguageSwitcher.vue
+++ b/src/components/LanguageSwitcher.vue
@@ -1,32 +1,35 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import {
+  applyDocumentLang,
+  isSupportedLocale,
+  writeStoredLocale,
+  type SupportedLocale,
+} from '@/utils/localePreference'
 
-const { locale, fallbackLocale, messages } = useI18n()
+const { locale } = useI18n()
 const currentLocale = ref(locale.value)
 
 const changeLanguage = () => {
-  locale.value = currentLocale.value
-  localStorage.setItem('user-locale', currentLocale.value)
-}
-
-// Initialize from localStorage if available, otherwise from browser
-const savedLocale = localStorage.getItem('user-locale')
-const supportedLocales = Object.keys(messages.value)
-
-if (savedLocale) {
-  currentLocale.value = savedLocale
-  locale.value = savedLocale
-} else {
-  const browserLocale = navigator.language.split('-')[0]
-  if (supportedLocales.includes(browserLocale)) {
-    currentLocale.value = browserLocale
-    locale.value = browserLocale
-  } else {
-    currentLocale.value = fallbackLocale.value as string
-    locale.value = fallbackLocale.value as string
+  const next = currentLocale.value
+  locale.value = next
+  if (isSupportedLocale(next)) {
+    writeStoredLocale(next as SupportedLocale)
   }
+  applyDocumentLang(String(next))
 }
+
+// Keep select in sync; persist + <html lang> when locale changes.
+watch(
+  locale,
+  (val) => {
+    currentLocale.value = val
+    if (isSupportedLocale(val)) writeStoredLocale(val)
+    applyDocumentLang(String(val))
+  },
+  { immediate: true },
+)
 </script>
 
 <template>
@@ -38,6 +41,7 @@ if (savedLocale) {
       @change="changeLanguage" 
       class="bg-transparent appearance-none text-sm hover:opacity-80 transition-opacity focus:ring-2 focus:ring-primary focus:outline-none rounded"
       :aria-label="$t('common.select_language')"
+      data-testid="language-select"
     >
       <option value="pt">{{ $t('common.portuguese') }}</option>
       <option value="en">{{ $t('common.english') }}</option>
@@ -63,4 +67,4 @@ if (savedLocale) {
   white-space: nowrap;
   border: 0;
 }
-</style> 
+</style>

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -2,11 +2,22 @@ import { createI18n } from 'vue-i18n'
 import pt from '../locales/pt.json'
 import en from '../locales/en.json'
 import es from '../locales/es.json'
+import {
+  applyDocumentLang,
+  readStoredLocale,
+  resolvePreferredLocale,
+} from '@/utils/localePreference'
+
+const initialLocale = resolvePreferredLocale(
+  typeof localStorage !== 'undefined' ? readStoredLocale() : null,
+  typeof navigator !== 'undefined' ? navigator.language : null,
+  'pt',
+)
 
 const i18n = createI18n({
   legacy: false, // Set to false to use Composition API
-  locale: 'pt', // set default locale to Portuguese
-  fallbackLocale: 'pt', // set fallback locale to Portuguese
+  locale: initialLocale,
+  fallbackLocale: 'pt',
   messages: {
     pt,
     en,
@@ -14,4 +25,6 @@ const i18n = createI18n({
   }
 })
 
-export default i18n 
+applyDocumentLang(initialLocale)
+
+export default i18n

--- a/src/utils/localePreference.spec.ts
+++ b/src/utils/localePreference.spec.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { isSupportedLocale, resolvePreferredLocale } from './localePreference';
+
+describe('localePreference', () => {
+  it('validates supported locales', () => {
+    expect(isSupportedLocale('pt')).toBe(true);
+    expect(isSupportedLocale('en')).toBe(true);
+    expect(isSupportedLocale('es')).toBe(true);
+    expect(isSupportedLocale('fr')).toBe(false);
+    expect(isSupportedLocale(null)).toBe(false);
+  });
+
+  it('prefers saved, then browser, then fallback', () => {
+    expect(resolvePreferredLocale('es', 'en-US', 'pt')).toBe('es');
+    expect(resolvePreferredLocale(null, 'en-GB', 'pt')).toBe('en');
+    expect(resolvePreferredLocale('nope', 'fr-FR', 'pt')).toBe('pt');
+    expect(resolvePreferredLocale(null, null, 'en')).toBe('en');
+  });
+});

--- a/src/utils/localePreference.ts
+++ b/src/utils/localePreference.ts
@@ -1,0 +1,41 @@
+export const LOCALE_STORAGE_KEY = 'user-locale';
+export const SUPPORTED_LOCALES = ['pt', 'en', 'es'] as const;
+export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
+
+export function isSupportedLocale(value: string | null | undefined): value is SupportedLocale {
+  return !!value && (SUPPORTED_LOCALES as readonly string[]).includes(value);
+}
+
+/** Prefer saved locale, then browser language prefix, then fallback. */
+export function resolvePreferredLocale(
+  saved: string | null | undefined,
+  browserLang: string | null | undefined,
+  fallback: SupportedLocale = 'pt',
+): SupportedLocale {
+  if (isSupportedLocale(saved)) return saved;
+  const prefix = (browserLang || '').split('-')[0]?.toLowerCase();
+  if (isSupportedLocale(prefix)) return prefix;
+  return fallback;
+}
+
+export function readStoredLocale(): string | null {
+  try {
+    return localStorage.getItem(LOCALE_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function writeStoredLocale(locale: SupportedLocale): void {
+  try {
+    localStorage.setItem(LOCALE_STORAGE_KEY, locale);
+  } catch {
+    /* private mode */
+  }
+}
+
+/** Keep document language in sync for a11y / SEO. */
+export function applyDocumentLang(locale: string): void {
+  if (typeof document === 'undefined') return;
+  document.documentElement.setAttribute('lang', locale);
+}


### PR DESCRIPTION
## Summary (agent-invented)
- **localePreference** util: resolve saved → browser → fallback; storage read/write; `applyDocumentLang`.
- **i18n** boots with resolved locale (not always `pt`).
- **LanguageSwitcher** uses shared helpers; sets `<html lang>`; `data-testid="language-select"`.

## Acceptance
- Unit tests for resolve/isSupported; build green; lang attribute updates on change.