### PR TITLE
feat: clear all home filters control

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1265,7 +1265,8 @@
     "quickLabel": "Quick filters",
     "beginners": "Beginner-friendly",
     "federated": "Federated / protocols",
-    "appCount": "Showing {shown} of {total} apps"
+    "appCount": "Showing {shown} of {total} apps",
+    "clear": "Clear filters"
   },
   "favorites": {
     "title": "Starred favorites",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1265,7 +1265,8 @@
     "quickLabel": "Filtros rápidos",
     "beginners": "Para principiantes",
     "federated": "Federados / protocolos",
-    "appCount": "Mostrando {shown} de {total} apps"
+    "appCount": "Mostrando {shown} de {total} apps",
+    "clear": "Limpiar filtros"
   },
   "favorites": {
     "title": "Favoritos con estrella",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -1265,7 +1265,8 @@
     "quickLabel": "Filtros rápidos",
     "beginners": "Para iniciantes",
     "federated": "Federados / protocolos",
-    "appCount": "Mostrando {shown} de {total} apps"
+    "appCount": "Mostrando {shown} de {total} apps",
+    "clear": "Limpar filtros"
   },
   "favorites": {
     "title": "Favoritos com estrela",

--- a/src/utils/homeFilters.spec.ts
+++ b/src/utils/homeFilters.spec.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { defaultHomeFilterState, hasActiveHomeFilters } from './homeFilters';
+
+describe('homeFilters', () => {
+  it('defaults are inactive', () => {
+    expect(hasActiveHomeFilters(defaultHomeFilterState())).toBe(false);
+  });
+
+  it('detects any active constraint', () => {
+    const base = defaultHomeFilterState();
+    expect(hasActiveHomeFilters({ ...base, searchQuery: 'mast' })).toBe(true);
+    expect(hasActiveHomeFilters({ ...base, selectedCategory: 'social' })).toBe(true);
+    expect(hasActiveHomeFilters({ ...base, selectedUseCase: 'chat' })).toBe(true);
+    expect(hasActiveHomeFilters({ ...base, beginnersOnly: true })).toBe(true);
+    expect(hasActiveHomeFilters({ ...base, federatedOnly: true })).toBe(true);
+  });
+});

--- a/src/utils/homeFilters.ts
+++ b/src/utils/homeFilters.ts
@@ -1,0 +1,28 @@
+export type HomeFilterState = {
+  searchQuery: string;
+  selectedCategory: string;
+  selectedUseCase: string;
+  beginnersOnly: boolean;
+  federatedOnly: boolean;
+};
+
+/** True when any home list constraint is active (not default browse-all). */
+export function hasActiveHomeFilters(state: HomeFilterState): boolean {
+  return (
+    !!state.searchQuery.trim() ||
+    state.selectedCategory !== 'all' ||
+    state.selectedUseCase !== 'all' ||
+    state.beginnersOnly ||
+    state.federatedOnly
+  );
+}
+
+export function defaultHomeFilterState(): HomeFilterState {
+  return {
+    searchQuery: '',
+    selectedCategory: 'all',
+    selectedUseCase: 'all',
+    beginnersOnly: false,
+    federatedOnly: false,
+  };
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -16,6 +16,7 @@ import type { App, CategoryId, UseCaseId } from '@/types';
 import { filterApps, shuffleAppsPurely, sortAppsByLinksThenRandom } from '@/utils/filter';
 import { getAppSlug } from '@/utils/global';
 import { applyQuickFilters } from '@/utils/quickFilters';
+import { hasActiveHomeFilters } from '@/utils/homeFilters';
 import {
   clearRecentApps,
   listRecentApps,
@@ -89,6 +90,25 @@ function toggleBeginnersOnly() {
 function toggleFederatedOnly() {
   federatedOnly.value = !federatedOnly.value;
   showFilters.value = true;
+  globalStore.resetReshuffle();
+}
+
+const filtersActive = computed(() =>
+  hasActiveHomeFilters({
+    searchQuery: searchQuery.value,
+    selectedCategory: selectedCategory.value,
+    selectedUseCase: selectedUseCase.value,
+    beginnersOnly: beginnersOnly.value,
+    federatedOnly: federatedOnly.value,
+  }),
+);
+
+function clearAllFilters() {
+  searchQuery.value = '';
+  selectedCategory.value = 'all';
+  selectedUseCase.value = 'all';
+  beginnersOnly.value = false;
+  federatedOnly.value = false;
   globalStore.resetReshuffle();
 }
 
@@ -395,6 +415,15 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
       >
         {{ t('filters.federated') }}
       </button>
+      <button
+        v-if="filtersActive"
+        type="button"
+        class="btn btn-ghost btn-sm"
+        data-testid="clear-filters"
+        @click="clearAllFilters"
+      >
+        {{ t('filters.clear') }}
+      </button>
     </div>
     <RecommendationWizard
       v-if="showWizard"
@@ -499,7 +528,7 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
   </p>
 
   <p
-    v-if="searchQuery.trim() || selectedCategory !== 'all' || selectedUseCase !== 'all' || beginnersOnly || federatedOnly"
+    v-if="filtersActive"
     class="text-sm text-center text-base-content/70 mb-3"
     data-testid="search-result-count"
     aria-live="polite"


### PR DESCRIPTION
## Summary (agent-invented)
- **Clear filters** button (`data-testid="clear-filters"`) appears when any home filter is active (search, category, use case, beginners, federated).
- Resets all constraints to defaults and reshuffle flag.
- Pure `hasActiveHomeFilters` / `defaultHomeFilterState` in `homeFilters.ts` with unit tests; `filters.clear` i18n en/pt/es.

## Acceptance
- Unit tests green; button only when filters active; clears all dimensions.