### PR TITLE
feat(a11y): skip link to main content

### DIFF
--- a/src/components/Layout.vue
+++ b/src/components/Layout.vue
@@ -1,16 +1,63 @@
 <script setup lang="ts">
 import Navbar from './Navbar.vue';
+import { useI18n } from 'vue-i18n';
+import { MAIN_CONTENT_ID, focusMainContent, mainContentHref } from '@/utils/skipLink';
+
+const { t } = useI18n();
+
+function onSkipActivate(event: Event) {
+  // Let the hash update, then move focus into main.
+  event.preventDefault();
+  const main = document.getElementById(MAIN_CONTENT_ID);
+  if (main) {
+    history.replaceState(null, '', mainContentHref());
+    focusMainContent();
+  }
+}
 </script>
 
 <template>
+  <a
+    :href="mainContentHref()"
+    class="skip-link"
+    data-testid="skip-to-main"
+    @click="onSkipActivate"
+  >
+    {{ t('a11y.skipToMain') }}
+  </a>
+
   <Navbar />
 
-  <main class="flex flex-col items-center min-h-dvh 
+  <main
+    :id="MAIN_CONTENT_ID"
+    class="flex flex-col items-center min-h-dvh 
     py-2 sm:py-4 md:py-6 lg:py-8 xl:py-10 
     px-2 sm:px-6 md:px-10 lg:px-16 xl:px-20 
-    max-w-7xl mx-auto">
+    max-w-7xl mx-auto"
+    tabindex="-1"
+  >
     <slot name="content" />
   </main>
 </template>
 
-<style scoped></style>
+<style scoped>
+.skip-link {
+  position: absolute;
+  left: 0.75rem;
+  top: 0.75rem;
+  z-index: 100;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  background: var(--fallback-p, oklch(var(--p)));
+  color: var(--fallback-pc, oklch(var(--pc)));
+  font-size: 0.875rem;
+  font-weight: 600;
+  transform: translateY(-150%);
+  transition: transform 0.15s ease;
+}
+.skip-link:focus {
+  transform: translateY(0);
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+</style>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1286,5 +1286,8 @@
     "modalPrev": "Previous app in modal",
     "modalNext": "Next app in modal",
     "escape": "Close modal / clear search"
+  },
+  "a11y": {
+    "skipToMain": "Skip to main content"
   }
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1286,5 +1286,8 @@
     "modalPrev": "App anterior en el modal",
     "modalNext": "Siguiente app en el modal",
     "escape": "Cerrar modal / limpiar búsqueda"
+  },
+  "a11y": {
+    "skipToMain": "Saltar al contenido principal"
   }
 }

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -1286,5 +1286,8 @@
     "modalPrev": "App anterior no modal",
     "modalNext": "Próximo app no modal",
     "escape": "Fechar modal / limpar busca"
+  },
+  "a11y": {
+    "skipToMain": "Ir para o conteúdo principal"
   }
 }

--- a/src/utils/skipLink.spec.ts
+++ b/src/utils/skipLink.spec.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { MAIN_CONTENT_ID, mainContentHref } from './skipLink';
+
+describe('skipLink', () => {
+  it('exposes stable main id and hash href', () => {
+    expect(MAIN_CONTENT_ID).toBe('main-content');
+    expect(mainContentHref()).toBe('#main-content');
+    expect(mainContentHref('custom')).toBe('#custom');
+  });
+});

--- a/src/utils/skipLink.ts
+++ b/src/utils/skipLink.ts
@@ -1,0 +1,16 @@
+/** Element id for the primary page landmark used by the skip link. */
+export const MAIN_CONTENT_ID = 'main-content';
+
+/** Build the in-page href for the skip control. */
+export function mainContentHref(id: string = MAIN_CONTENT_ID): string {
+  return `#${id}`;
+}
+
+/** Focus main landmark after skip activation (a11y). */
+export function focusMainContent(id: string = MAIN_CONTENT_ID): void {
+  if (typeof document === 'undefined') return;
+  const el = document.getElementById(id);
+  if (!el) return;
+  if (!el.hasAttribute('tabindex')) el.setAttribute('tabindex', '-1');
+  el.focus({ preventScroll: false });
+}


### PR DESCRIPTION
## Summary (agent-invented)
- Skip link (`data-testid="skip-to-main"`) appears on keyboard focus; moves focus to `#main-content`.
- Layout `main` landmark gets stable id + tabindex for programmatic focus.
- `skipLink` util (id/href/focus helper) with unit tests; i18n `a11y.skipToMain`.

## Acceptance
- Unit tests pass; skip control in DOM; main has `id="main-content"`.