### PR TITLE
feat: starred-only quick filter chip

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1266,7 +1266,8 @@
     "beginners": "Beginner-friendly",
     "federated": "Federated / protocols",
     "appCount": "Showing {shown} of {total} apps",
-    "clear": "Clear filters"
+    "clear": "Clear filters",
+    "starred": "Starred only"
   },
   "favorites": {
     "title": "Starred favorites",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1266,7 +1266,8 @@
     "beginners": "Para principiantes",
     "federated": "Federados / protocolos",
     "appCount": "Mostrando {shown} de {total} apps",
-    "clear": "Limpiar filtros"
+    "clear": "Limpiar filtros",
+    "starred": "Solo favoritos"
   },
   "favorites": {
     "title": "Favoritos con estrella",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -1266,7 +1266,8 @@
     "beginners": "Para iniciantes",
     "federated": "Federados / protocolos",
     "appCount": "Mostrando {shown} de {total} apps",
-    "clear": "Limpar filtros"
+    "clear": "Limpar filtros",
+    "starred": "Só favoritos"
   },
   "favorites": {
     "title": "Favoritos com estrela",

--- a/src/utils/homeFilters.spec.ts
+++ b/src/utils/homeFilters.spec.ts
@@ -1,17 +1,29 @@
 import { describe, it, expect } from 'vitest';
-import { defaultHomeFilterState, hasActiveHomeFilters } from './homeFilters';
+import {
+  defaultHomeFilterState,
+  filterStarredOnly,
+  hasActiveHomeFilters,
+} from './homeFilters';
 
 describe('homeFilters', () => {
   it('defaults are inactive', () => {
     expect(hasActiveHomeFilters(defaultHomeFilterState())).toBe(false);
   });
 
-  it('detects any active constraint', () => {
+  it('detects any active constraint including starredOnly', () => {
     const base = defaultHomeFilterState();
     expect(hasActiveHomeFilters({ ...base, searchQuery: 'mast' })).toBe(true);
     expect(hasActiveHomeFilters({ ...base, selectedCategory: 'social' })).toBe(true);
     expect(hasActiveHomeFilters({ ...base, selectedUseCase: 'chat' })).toBe(true);
     expect(hasActiveHomeFilters({ ...base, beginnersOnly: true })).toBe(true);
     expect(hasActiveHomeFilters({ ...base, federatedOnly: true })).toBe(true);
+    expect(hasActiveHomeFilters({ ...base, starredOnly: true })).toBe(true);
+  });
+
+  it('filterStarredOnly keeps matching names only when enabled', () => {
+    const list = [{ name: 'A' }, { name: 'B' }, { name: 'C' }];
+    expect(filterStarredOnly(list, ['B'], false).map((a) => a.name)).toEqual(['A', 'B', 'C']);
+    expect(filterStarredOnly(list, ['B', 'C'], true).map((a) => a.name)).toEqual(['B', 'C']);
+    expect(filterStarredOnly(list, [], true)).toEqual([]);
   });
 });

--- a/src/utils/homeFilters.ts
+++ b/src/utils/homeFilters.ts
@@ -4,6 +4,7 @@ export type HomeFilterState = {
   selectedUseCase: string;
   beginnersOnly: boolean;
   federatedOnly: boolean;
+  starredOnly?: boolean;
 };
 
 /** True when any home list constraint is active (not default browse-all). */
@@ -13,7 +14,8 @@ export function hasActiveHomeFilters(state: HomeFilterState): boolean {
     state.selectedCategory !== 'all' ||
     state.selectedUseCase !== 'all' ||
     state.beginnersOnly ||
-    state.federatedOnly
+    state.federatedOnly ||
+    !!state.starredOnly
   );
 }
 
@@ -24,5 +26,18 @@ export function defaultHomeFilterState(): HomeFilterState {
     selectedUseCase: 'all',
     beginnersOnly: false,
     federatedOnly: false,
+    starredOnly: false,
   };
+}
+
+/** Keep apps whose name is in the starred set (order preserved from list). */
+export function filterStarredOnly<T extends { name: string }>(
+  list: T[],
+  starredNames: Iterable<string>,
+  enabled: boolean,
+): T[] {
+  if (!enabled) return list;
+  const set = starredNames instanceof Set ? starredNames : new Set(starredNames);
+  if (set.size === 0) return [];
+  return list.filter((a) => set.has(a.name));
 }

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -16,7 +16,7 @@ import type { App, CategoryId, UseCaseId } from '@/types';
 import { filterApps, shuffleAppsPurely, sortAppsByLinksThenRandom } from '@/utils/filter';
 import { getAppSlug } from '@/utils/global';
 import { applyQuickFilters } from '@/utils/quickFilters';
-import { hasActiveHomeFilters } from '@/utils/homeFilters';
+import { filterStarredOnly, hasActiveHomeFilters } from '@/utils/homeFilters';
 import {
   clearRecentApps,
   listRecentApps,
@@ -50,6 +50,7 @@ const showWizard = ref(false);
 const showShortcuts = ref(false);
 const beginnersOnly = ref(false);
 const federatedOnly = ref(false);
+const starredOnly = ref(false);
 /** Bump when recent list changes so the chip row re-renders. */
 const recentTick = ref(0);
 /** Bump when stars change so favorites row re-renders (stars toggle in modal). */
@@ -75,10 +76,11 @@ const filteredApps = computed(() => {
     searchQuery.value,
     selectedUseCase.value,
   );
-  return applyQuickFilters(list, {
+  const quick = applyQuickFilters(list, {
     beginnersOnly: beginnersOnly.value,
     federatedOnly: federatedOnly.value,
   });
+  return filterStarredOnly(quick, listStarredApps(), starredOnly.value);
 });
 
 function toggleBeginnersOnly() {
@@ -93,6 +95,13 @@ function toggleFederatedOnly() {
   globalStore.resetReshuffle();
 }
 
+function toggleStarredOnly() {
+  starredOnly.value = !starredOnly.value;
+  showFilters.value = true;
+  starsTick.value += 1;
+  globalStore.resetReshuffle();
+}
+
 const filtersActive = computed(() =>
   hasActiveHomeFilters({
     searchQuery: searchQuery.value,
@@ -100,6 +109,7 @@ const filtersActive = computed(() =>
     selectedUseCase: selectedUseCase.value,
     beginnersOnly: beginnersOnly.value,
     federatedOnly: federatedOnly.value,
+    starredOnly: starredOnly.value,
   }),
 );
 
@@ -109,6 +119,7 @@ function clearAllFilters() {
   selectedUseCase.value = 'all';
   beginnersOnly.value = false;
   federatedOnly.value = false;
+  starredOnly.value = false;
   globalStore.resetReshuffle();
 }
 
@@ -414,6 +425,16 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
         @click="toggleFederatedOnly"
       >
         {{ t('filters.federated') }}
+      </button>
+      <button
+        type="button"
+        class="btn btn-sm"
+        :class="starredOnly ? 'btn-primary' : 'btn-outline'"
+        data-testid="chip-starred"
+        :aria-pressed="starredOnly"
+        @click="toggleStarredOnly"
+      >
+        {{ t('filters.starred') }}
       </button>
       <button
         v-if="filtersActive"


### PR DESCRIPTION
## Summary (agent-invented)
- New **Starred only** quick chip (`data-testid="chip-starred"`) filters the home grid to apps the user has starred.
- `filterStarredOnly` + `starredOnly` in active-filters / clear-all; i18n `filters.starred` en/pt/es.

## Acceptance
- Unit tests for starred filter and active detection; empty stars ⇒ empty list when chip on.