### PR TITLE
feat(a11y): scroll-to-top floating button

### DIFF
--- a/src/components/Layout.vue
+++ b/src/components/Layout.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import Navbar from './Navbar.vue';
+import ScrollToTopButton from './ScrollToTopButton.vue';
 import { useI18n } from 'vue-i18n';
 import { MAIN_CONTENT_ID, focusMainContent, mainContentHref } from '@/utils/skipLink';
 
@@ -38,6 +39,8 @@ function onSkipActivate(event: Event) {
   >
     <slot name="content" />
   </main>
+
+  <ScrollToTopButton />
 </template>
 
 <style scoped>

--- a/src/components/ScrollToTopButton.vue
+++ b/src/components/ScrollToTopButton.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { scrollWindowToTop, shouldShowScrollToTop } from '@/utils/scrollToTop';
+
+const { t } = useI18n();
+const visible = ref(false);
+
+function onScroll() {
+  visible.value = shouldShowScrollToTop(window.scrollY || window.pageYOffset || 0);
+}
+
+function onClick() {
+  scrollWindowToTop('smooth');
+}
+
+onMounted(() => {
+  onScroll();
+  window.addEventListener('scroll', onScroll, { passive: true });
+});
+
+onUnmounted(() => {
+  window.removeEventListener('scroll', onScroll);
+});
+</script>
+
+<template>
+  <button
+    v-show="visible"
+    type="button"
+    class="btn btn-circle btn-primary btn-sm fixed bottom-4 right-4 z-50 shadow-lg"
+    data-testid="scroll-to-top"
+    :aria-label="t('a11y.scrollToTop')"
+    @click="onClick"
+  >
+    ↑
+  </button>
+</template>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1289,6 +1289,7 @@
     "escape": "Close modal / clear search"
   },
   "a11y": {
-    "skipToMain": "Skip to main content"
+    "skipToMain": "Skip to main content",
+    "scrollToTop": "Back to top"
   }
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1289,6 +1289,7 @@
     "escape": "Cerrar modal / limpiar búsqueda"
   },
   "a11y": {
-    "skipToMain": "Saltar al contenido principal"
+    "skipToMain": "Saltar al contenido principal",
+    "scrollToTop": "Volver arriba"
   }
 }

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -1289,6 +1289,7 @@
     "escape": "Fechar modal / limpar busca"
   },
   "a11y": {
-    "skipToMain": "Ir para o conteúdo principal"
+    "skipToMain": "Ir para o conteúdo principal",
+    "scrollToTop": "Voltar ao topo"
   }
 }

--- a/src/utils/scrollToTop.spec.ts
+++ b/src/utils/scrollToTop.spec.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { SCROLL_TOP_THRESHOLD_PX, shouldShowScrollToTop } from './scrollToTop';
+
+describe('scrollToTop', () => {
+  it('hides below threshold and shows at/above', () => {
+    expect(shouldShowScrollToTop(0)).toBe(false);
+    expect(shouldShowScrollToTop(SCROLL_TOP_THRESHOLD_PX - 1)).toBe(false);
+    expect(shouldShowScrollToTop(SCROLL_TOP_THRESHOLD_PX)).toBe(true);
+    expect(shouldShowScrollToTop(900, 100)).toBe(true);
+  });
+});

--- a/src/utils/scrollToTop.ts
+++ b/src/utils/scrollToTop.ts
@@ -1,0 +1,14 @@
+/** Show the control after the user scrolls past this many pixels. */
+export const SCROLL_TOP_THRESHOLD_PX = 320;
+
+export function shouldShowScrollToTop(
+  scrollY: number,
+  threshold: number = SCROLL_TOP_THRESHOLD_PX,
+): boolean {
+  return scrollY >= threshold;
+}
+
+export function scrollWindowToTop(behavior: ScrollBehavior = 'smooth'): void {
+  if (typeof window === 'undefined') return;
+  window.scrollTo({ top: 0, left: 0, behavior });
+}


### PR DESCRIPTION
## Summary (agent-invented)
- **Back to top** button (`data-testid="scroll-to-top"`) shows after scrolling ~320px; smooth scroll to top.
- Pure `shouldShowScrollToTop` threshold helper with unit tests; i18n `a11y.scrollToTop` en/pt/es.

## Acceptance
- Button absent at scroll 0; present after scroll; click scrolls window.