### PR TITLE
feat: sync home search to ?q= URL param

### DIFF
--- a/src/utils/searchQueryUrl.spec.ts
+++ b/src/utils/searchQueryUrl.spec.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SEARCH_QUERY_PARAM,
+  parseSearchQueryParam,
+  withSearchQueryParam,
+} from './searchQueryUrl';
+
+describe('searchQueryUrl', () => {
+  it('parses scalar and array query values', () => {
+    expect(parseSearchQueryParam(undefined)).toBe('');
+    expect(parseSearchQueryParam('mastodon')).toBe('mastodon');
+    expect(parseSearchQueryParam(['a', 'b'])).toBe('a');
+    expect(parseSearchQueryParam([])).toBe('');
+  });
+
+  it('sets or removes q while preserving other keys', () => {
+    expect(withSearchQueryParam({ app: 'x' }, '  hi  ')).toEqual({ app: 'x', q: 'hi' });
+    expect(withSearchQueryParam({ app: 'x', q: 'old' }, '   ')).toEqual({ app: 'x' });
+    expect(SEARCH_QUERY_PARAM).toBe('q');
+  });
+});

--- a/src/utils/searchQueryUrl.ts
+++ b/src/utils/searchQueryUrl.ts
@@ -1,0 +1,28 @@
+/** Query-string key for the home search box. */
+export const SEARCH_QUERY_PARAM = 'q';
+
+/** Normalize route query value (string | string[] | null/undefined) to a search string. */
+export function parseSearchQueryParam(raw: unknown): string {
+  if (raw == null) return '';
+  if (Array.isArray(raw)) {
+    const first = raw.find((x) => typeof x === 'string' && x.length > 0);
+    return typeof first === 'string' ? first : '';
+  }
+  return typeof raw === 'string' ? raw : '';
+}
+
+/**
+ * Build the next query object for the router: set `q` when non-empty, omit when empty.
+ * Preserves unrelated keys (e.g. `app`).
+ */
+export function withSearchQueryParam(
+  current: Record<string, unknown>,
+  searchText: string,
+  param: string = SEARCH_QUERY_PARAM,
+): Record<string, unknown> {
+  const next: Record<string, unknown> = { ...current };
+  const trimmed = searchText.trim();
+  if (trimmed) next[param] = trimmed;
+  else delete next[param];
+  return next;
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -17,6 +17,7 @@ import { filterApps, shuffleAppsPurely, sortAppsByLinksThenRandom } from '@/util
 import { getAppSlug } from '@/utils/global';
 import { applyQuickFilters } from '@/utils/quickFilters';
 import { filterStarredOnly, hasActiveHomeFilters } from '@/utils/homeFilters';
+import { parseSearchQueryParam, withSearchQueryParam } from '@/utils/searchQueryUrl';
 import {
   clearRecentApps,
   listRecentApps,
@@ -239,6 +240,11 @@ function onGlobalKeydown(e: KeyboardEvent) {
 }
 
 onMounted(() => {
+  const fromUrl = parseSearchQueryParam(route.query.q);
+  if (fromUrl) {
+    searchQuery.value = fromUrl;
+    showFilters.value = true;
+  }
   const appSlug = route.query.app;
   if (appSlug) {
     const found = apps.value.find(app => getAppSlug(app) === appSlug);
@@ -340,6 +346,16 @@ watch([mostrarModal, modalData], ([isOpen, app]) => {
         'Apps descentralizados que funcionam sem um único dono, com redes independentes, mais liberdade, privacidade e controle para quem participa.',
     });
   }
+});
+
+
+/** Keep ?q= in sync so filtered views are shareable / reloadable. */
+watch(searchQuery, (q) => {
+  const cur = parseSearchQueryParam(route.query.q);
+  const trimmed = q.trim();
+  if (trimmed === cur) return;
+  const next = withSearchQueryParam({ ...route.query } as Record<string, unknown>, q);
+  router.replace({ query: next as typeof route.query });
 });
 
 watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCase]) => {


### PR DESCRIPTION
## Summary (agent-invented)
- Home search is reflected in `?q=` so filtered views are **shareable/reloadable**.
- `searchQueryUrl` util (`parseSearchQueryParam`, `withSearchQueryParam`) + tests.
- Hydrates search on mount; preserves other query keys (e.g. `app`).

## Acceptance
- Unit tests pass; visiting `?q=mastodon` populates search; typing updates URL.