### PR TITLE
feat: copy current page link button

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1291,5 +1291,9 @@
   "a11y": {
     "skipToMain": "Skip to main content",
     "scrollToTop": "Back to top"
+  },
+  "share": {
+    "copyLink": "Copy page link",
+    "copied": "Link copied!"
   }
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1291,5 +1291,9 @@
   "a11y": {
     "skipToMain": "Saltar al contenido principal",
     "scrollToTop": "Volver arriba"
+  },
+  "share": {
+    "copyLink": "Copiar enlace de la página",
+    "copied": "¡Enlace copiado!"
   }
 }

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -1291,5 +1291,9 @@
   "a11y": {
     "skipToMain": "Ir para o conteúdo principal",
     "scrollToTop": "Voltar ao topo"
+  },
+  "share": {
+    "copyLink": "Copiar link da página",
+    "copied": "Link copiado!"
   }
 }

--- a/src/utils/pageLink.spec.ts
+++ b/src/utils/pageLink.spec.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { buildPageLink, currentPageLink } from './pageLink';
+
+describe('pageLink', () => {
+  it('composes origin path query hash', () => {
+    expect(buildPageLink('https://sovereinia.org', '/guia/', '?q=x', '')).toBe(
+      'https://sovereinia.org/guia/?q=x',
+    );
+    expect(buildPageLink('https://a.com/', 'guia', 'q=1', 'top')).toBe('https://a.com/guia?q=1#top');
+  });
+
+  it('currentPageLink uses href when absolute', () => {
+    expect(currentPageLink({ href: 'https://ex.com/guia/?q=m', hash: '' })).toContain('q=m');
+  });
+});

--- a/src/utils/pageLink.ts
+++ b/src/utils/pageLink.ts
@@ -1,0 +1,25 @@
+/** Build an absolute URL for the current app location (shareable). */
+export function buildPageLink(
+  origin: string,
+  pathname: string,
+  search: string = '',
+  hash: string = '',
+): string {
+  const path = pathname.startsWith('/') ? pathname : `/${pathname}`;
+  const q = search && !search.startsWith('?') && search.length > 0 ? `?${search}` : search;
+  const h = hash && !hash.startsWith('#') && hash.length > 0 ? `#${hash}` : hash;
+  const base = origin.replace(/\/$/, '');
+  return `${base}${path}${q || ''}${h || ''}`;
+}
+
+/** Prefer full href from Location-like; fallback to composed parts. */
+export function currentPageLink(loc: {
+  href?: string;
+  origin?: string;
+  pathname?: string;
+  search?: string;
+  hash?: string;
+}): string {
+  if (loc.href && /^https?:\/\//i.test(loc.href)) return loc.href.split('#')[0] + (loc.hash || '');
+  return buildPageLink(loc.origin || '', loc.pathname || '/', loc.search || '', loc.hash || '');
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -18,6 +18,7 @@ import { getAppSlug } from '@/utils/global';
 import { applyQuickFilters } from '@/utils/quickFilters';
 import { filterStarredOnly, hasActiveHomeFilters } from '@/utils/homeFilters';
 import { parseSearchQueryParam, withSearchQueryParam } from '@/utils/searchQueryUrl';
+import { currentPageLink } from '@/utils/pageLink';
 import {
   clearRecentApps,
   listRecentApps,
@@ -57,6 +58,7 @@ const recentTick = ref(0);
 /** Bump when stars change so favorites row re-renders (stars toggle in modal). */
 const starsTick = ref(0);
 const favoritesCopied = ref(false);
+const pageLinkCopied = ref(false);
 const route = useRoute();
 const router = useRouter();
 
@@ -147,6 +149,20 @@ function onClearRecent() {
 
 function refreshStarsTick() {
   starsTick.value += 1;
+}
+
+
+async function onCopyPageLink() {
+  const url = currentPageLink(window.location);
+  try {
+    await navigator.clipboard.writeText(url);
+  } catch {
+    /* clipboard may be blocked in some contexts */
+  }
+  pageLinkCopied.value = true;
+  window.setTimeout(() => {
+    pageLinkCopied.value = false;
+  }, 2000);
 }
 
 async function onExportFavorites() {
@@ -414,6 +430,14 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
       >
         {{ t('shortcuts.open') }}
         <kbd class="ml-1 opacity-60 font-mono text-xs">?</kbd>
+      </button>
+      <button
+        type="button"
+        class="btn btn-ghost btn-sm"
+        data-testid="copy-page-link"
+        @click="onCopyPageLink"
+      >
+        {{ pageLinkCopied ? t('share.copied') : t('share.copyLink') }}
       </button>
     </div>
     <div


### PR DESCRIPTION
## Summary (agent-invented)
- Toolbar **Copy page link** (`data-testid="copy-page-link"`) copies the current URL (search/filters in query preserved).
- `pageLink` util + unit tests; i18n `share.copyLink` / `share.copied`.

## Acceptance
- Button present; util builds absolute paths; feedback label after click.