### PR TITLE
feat: Esc clears home filters when modal closed

### DIFF
--- a/src/utils/escapeAction.spec.ts
+++ b/src/utils/escapeAction.spec.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { resolveEscapeAction } from './escapeAction';
+
+describe('resolveEscapeAction', () => {
+  it('prioritizes shortcuts, then modal, then clear filters', () => {
+    expect(
+      resolveEscapeAction({ shortcutsOpen: true, modalOpen: true, filtersActive: true }),
+    ).toBe('close-shortcuts');
+    expect(
+      resolveEscapeAction({ shortcutsOpen: false, modalOpen: true, filtersActive: true }),
+    ).toBe('ignore-modal');
+    expect(
+      resolveEscapeAction({ shortcutsOpen: false, modalOpen: false, filtersActive: true }),
+    ).toBe('clear-filters');
+    expect(
+      resolveEscapeAction({ shortcutsOpen: false, modalOpen: false, filtersActive: false }),
+    ).toBe('none');
+  });
+});

--- a/src/utils/escapeAction.ts
+++ b/src/utils/escapeAction.ts
@@ -1,0 +1,15 @@
+export type EscapeUiState = {
+  shortcutsOpen: boolean;
+  modalOpen: boolean;
+  filtersActive: boolean;
+};
+
+export type EscapeAction = 'close-shortcuts' | 'ignore-modal' | 'clear-filters' | 'none';
+
+/** Decide what Escape should do on the home shell (modal owns its own Esc). */
+export function resolveEscapeAction(state: EscapeUiState): EscapeAction {
+  if (state.shortcutsOpen) return 'close-shortcuts';
+  if (state.modalOpen) return 'ignore-modal';
+  if (state.filtersActive) return 'clear-filters';
+  return 'none';
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -19,6 +19,7 @@ import { applyQuickFilters } from '@/utils/quickFilters';
 import { filterStarredOnly, hasActiveHomeFilters } from '@/utils/homeFilters';
 import { parseSearchQueryParam, withSearchQueryParam } from '@/utils/searchQueryUrl';
 import { currentPageLink } from '@/utils/pageLink';
+import { resolveEscapeAction } from '@/utils/escapeAction';
 import {
   clearRecentApps,
   listRecentApps,
@@ -243,9 +244,24 @@ function onGlobalKeydown(e: KeyboardEvent) {
     return;
   }
 
-  if (showShortcuts.value && e.key === 'Escape') {
-    e.preventDefault();
-    showShortcuts.value = false;
+  if (e.key === 'Escape') {
+    const action = resolveEscapeAction({
+      shortcutsOpen: showShortcuts.value,
+      modalOpen: mostrarModal.value,
+      filtersActive: filtersActive.value,
+    });
+    if (action === 'close-shortcuts') {
+      e.preventDefault();
+      showShortcuts.value = false;
+      return;
+    }
+    if (action === 'clear-filters') {
+      // Allow Esc from the search field too (clears query/filters).
+      e.preventDefault();
+      clearAllFilters();
+      return;
+    }
+    // modalOpen: let dialog handle Esc
     return;
   }
 


### PR DESCRIPTION
## Summary (agent-invented)
- **Escape** on home clears active filters/search when shortcuts are closed and the app modal is not open (shortcuts help already listed this behavior).
- Pure `resolveEscapeAction` priority helper + unit tests.

## Acceptance
- Unit tests for action priority; Esc clears beginners chip / `?q=` when filters active.