### PR TITLE
feat(a11y): safe external link attrs on navbar

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -3,8 +3,12 @@ import { computed } from 'vue';
 import ThemeToggler from './ThemeToggler.vue';
 import LanguageSwitcher from './LanguageSwitcher.vue';
 import { useI18n } from 'vue-i18n';
+import { externalLinkAttrs } from '@/utils/externalLink';
 
 const { t } = useI18n();
+
+const homeHref = 'https://sovereinia.org/';
+const homeLinkAttrs = externalLinkAttrs(homeHref);
 
 const navOptions = computed(() => [
   {
@@ -18,9 +22,11 @@ const navOptions = computed(() => [
   <nav class="navbar px-8" role="navigation" aria-label="Main navigation">
     <div class="flex-1">
       <a
-        href="https://sovereinia.org/"
+        :href="homeHref"
         class="hover:opacity-80 transition-opacity text-2xl font-bold text-color"
         aria-label="Sovereinia homepage"
+        v-bind="homeLinkAttrs"
+        data-testid="nav-home-link"
       >
         Sovereinia
       </a>
@@ -31,6 +37,8 @@ const navOptions = computed(() => [
           <a 
             :href="option.link" 
             class="hover:opacity-80 transition-opacity"
+            v-bind="externalLinkAttrs(option.link)"
+            data-testid="nav-external-link"
           >
             {{ option.name }}
           </a>

--- a/src/utils/externalLink.spec.ts
+++ b/src/utils/externalLink.spec.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { externalLinkAttrs, isExternalHttpUrl } from './externalLink';
+
+describe('externalLink', () => {
+  it('detects absolute http(s) urls', () => {
+    expect(isExternalHttpUrl('https://sovereinia.org/')).toBe(true);
+    expect(isExternalHttpUrl('http://example.com')).toBe(true);
+    expect(isExternalHttpUrl('/guia/')).toBe(false);
+    expect(isExternalHttpUrl(null)).toBe(false);
+  });
+
+  it('sets target+rel only for external urls', () => {
+    expect(externalLinkAttrs('https://a.com')).toEqual({
+      target: '_blank',
+      rel: 'noopener noreferrer',
+    });
+    expect(externalLinkAttrs('/local')).toEqual({});
+  });
+});

--- a/src/utils/externalLink.ts
+++ b/src/utils/externalLink.ts
@@ -1,0 +1,17 @@
+/** True for absolute http(s) URLs (treat as leaving the app). */
+export function isExternalHttpUrl(href: string | undefined | null): boolean {
+  if (!href) return false;
+  return /^https?:\/\//i.test(href.trim());
+}
+
+/**
+ * Safe attributes for outbound anchors.
+ * Same-origin / relative links keep default tab behavior.
+ */
+export function externalLinkAttrs(href: string | undefined | null): {
+  target?: '_blank';
+  rel?: string;
+} {
+  if (!isExternalHttpUrl(href)) return {};
+  return { target: '_blank', rel: 'noopener noreferrer' };
+}


### PR DESCRIPTION
## Summary (agent-invented)
- Shared `externalLinkAttrs` / `isExternalHttpUrl` for outbound anchors.
- Navbar Sovereinia + blog links get `target=_blank` + `rel=noopener noreferrer` via util; testids for smoke.

## Acceptance
- Unit tests pass; nav home link has rel noopener on live/local.