### PR TITLE
feat: surprise-me respects filters via pickRandom util

### DIFF
--- a/src/components/form/SurpriseMeButton.vue
+++ b/src/components/form/SurpriseMeButton.vue
@@ -2,6 +2,7 @@
 import { ref } from 'vue';
 import type { App } from '@/types';
 import { useI18n } from 'vue-i18n';
+import { pickRandomItem } from '@/utils/pickRandom';
 
 const { t } = useI18n();
 
@@ -16,12 +17,10 @@ const emit = defineEmits<{
 const isAnimating = ref(false);
 
 function surpriseMe() {
-  if (isAnimating.value || !props.apps.length) return;
-  
-  const randomIndex = Math.floor(Math.random() * props.apps.length);
-  const randomApp = props.apps[randomIndex];
-  
-  // Add some animation feedback
+  if (isAnimating.value) return;
+  const randomApp = pickRandomItem(props.apps);
+  if (!randomApp) return;
+
   isAnimating.value = true;
   setTimeout(() => {
     isAnimating.value = false;
@@ -32,15 +31,17 @@ function surpriseMe() {
 
 <template>
   <button
+    type="button"
+    data-testid="surprise-me"
     @click="surpriseMe"
-    :disabled="isAnimating"
+    :disabled="isAnimating || !apps.length"
     class="btn btn-primary btn-md rounded-full flex items-center gap-1 sm:gap-2 transition-all duration-300 whitespace-nowrap"
     :class="{
       'animate-pulse': isAnimating,
       'scale-95': isAnimating
     }"
   >
-    <span class="text-base sm:text-lg">🎲</span>
+    <span class="text-base sm:text-lg" aria-hidden="true">🎲</span>
     <span class="text-sm sm:text-base hidden md:block">{{ t('surpriseMe.button', 'Surprise me!') }}</span>
   </button>
 </template>

--- a/src/utils/pickRandom.spec.ts
+++ b/src/utils/pickRandom.spec.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { pickRandomItem } from './pickRandom';
+
+describe('pickRandomItem', () => {
+  it('returns undefined for empty list', () => {
+    expect(pickRandomItem([])).toBeUndefined();
+  });
+
+  it('uses injected random for stable index', () => {
+    const items = ['a', 'b', 'c'];
+    expect(pickRandomItem(items, () => 0)).toBe('a');
+    expect(pickRandomItem(items, () => 0.99)).toBe('c');
+  });
+});

--- a/src/utils/pickRandom.ts
+++ b/src/utils/pickRandom.ts
@@ -1,0 +1,10 @@
+/** Pick one element pseudo-randomly; returns undefined for empty input. */
+export function pickRandomItem<T>(
+  items: readonly T[],
+  random: () => number = Math.random,
+): T | undefined {
+  if (!items.length) return undefined;
+  const r = random();
+  const idx = Math.min(items.length - 1, Math.max(0, Math.floor(r * items.length)));
+  return items[idx];
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -522,7 +522,7 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
       </div>
       <div class="flex-shrink-0 flex gap-2">
         <SurpriseMeButton 
-          :apps="orderedApps" 
+          :apps="filteredApps" 
           @surprise="handleSurpriseMe"
         />
         <ReshuffleButton />


### PR DESCRIPTION
## Summary (agent-invented)
- Pure `pickRandomItem` with injectable RNG + unit tests.
- Surprise Me uses the helper, disables when no apps, `data-testid="surprise-me"`.
- Home passes **filteredApps** so surprise honors active search/chips.

## Acceptance
- Unit tests pass; surprise button present and disabled under impossible filter if none match.