### PR TITLE
feat(a11y): i18n theme toggle + nextTheme util

### DIFF
--- a/src/components/ThemeToggler.vue
+++ b/src/components/ThemeToggler.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import { useGlobalStore } from '../stores/global';
+import { useI18n } from 'vue-i18n';
 
 const globalStore = useGlobalStore();
+const { t } = useI18n();
 
-// changing theme by pressing enter when focused 
 const handleKeyDown = (event: KeyboardEvent) => {
   if (event.key === 'Enter' || event.key === ' ') {
     event.preventDefault();
@@ -15,14 +16,14 @@ const handleKeyDown = (event: KeyboardEvent) => {
 <template>
   <button 
     type="button"
+    data-testid="theme-toggle"
     class="swap swap-rotate cursor-pointer focus:ring-2 focus:ring-primary focus:outline-none rounded p-1"
     :class="{ 'swap-active': globalStore.isDark }"
     @click="globalStore.toggleTheme"
     @keydown="handleKeyDown"
-    :aria-label="globalStore.isDark ? 'Switch to light theme' : 'Switch to dark theme'"
+    :aria-label="globalStore.isDark ? t('theme.toLight') : t('theme.toDark')"
     :aria-pressed="globalStore.isDark"
   >
-    <!-- Sun icon (light mode) -->
     <svg
       class="swap-off h-6 w-6 fill-current"
       xmlns="http://www.w3.org/2000/svg"
@@ -35,7 +36,6 @@ const handleKeyDown = (event: KeyboardEvent) => {
       />
     </svg>
 
-    <!-- Moon icon (dark mode) -->
     <svg
       class="swap-on h-6 w-6 fill-current"
       xmlns="http://www.w3.org/2000/svg"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1295,5 +1295,9 @@
   "share": {
     "copyLink": "Copy page link",
     "copied": "Link copied!"
+  },
+  "theme": {
+    "toLight": "Switch to light theme",
+    "toDark": "Switch to dark theme"
   }
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1295,5 +1295,9 @@
   "share": {
     "copyLink": "Copiar enlace de la página",
     "copied": "¡Enlace copiado!"
+  },
+  "theme": {
+    "toLight": "Cambiar a tema claro",
+    "toDark": "Cambiar a tema oscuro"
   }
 }

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -1295,5 +1295,9 @@
   "share": {
     "copyLink": "Copiar link da página",
     "copied": "Link copiado!"
+  },
+  "theme": {
+    "toLight": "Mudar para tema claro",
+    "toDark": "Mudar para tema escuro"
   }
 }

--- a/src/stores/global.ts
+++ b/src/stores/global.ts
@@ -1,5 +1,6 @@
 import { computed, ref } from 'vue';
 import { defineStore } from 'pinia';
+import { nextTheme } from '@/utils/theme';
 
 export const useGlobalStore = defineStore(
   'global',
@@ -12,7 +13,7 @@ export const useGlobalStore = defineStore(
 
     const toggleTheme = () => {
       if (!html) return;
-      theme.value = theme.value === 'light' ? 'dark' : 'light';
+      theme.value = nextTheme(theme.value);
       html.setAttribute('data-theme', theme.value);
 
       if (isDark.value) {

--- a/src/utils/theme.spec.ts
+++ b/src/utils/theme.spec.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { isDarkTheme, nextTheme } from './theme';
+
+describe('theme', () => {
+  it('toggles light/dark', () => {
+    expect(nextTheme('light')).toBe('dark');
+    expect(nextTheme('dark')).toBe('light');
+    expect(nextTheme('other')).toBe('dark');
+  });
+
+  it('detects dark', () => {
+    expect(isDarkTheme('dark')).toBe(true);
+    expect(isDarkTheme('light')).toBe(false);
+  });
+});

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -1,0 +1,9 @@
+export type ThemeName = 'light' | 'dark';
+
+export function nextTheme(current: string): ThemeName {
+  return current === 'dark' ? 'light' : 'dark';
+}
+
+export function isDarkTheme(current: string): boolean {
+  return current === 'dark';
+}


### PR DESCRIPTION
## Summary (agent-invented)
- `nextTheme` / `isDarkTheme` util + unit tests; global store uses `nextTheme`.
- Theme toggler aria labels via i18n (`theme.toLight` / `theme.toDark`); `data-testid="theme-toggle"`.

## Acceptance
- Unit tests pass; theme button has testid on home.