### PR TITLE
feat(a11y): reshuffle button testid + shuffle util

### DIFF
--- a/src/components/form/ReshuffleButton.vue
+++ b/src/components/form/ReshuffleButton.vue
@@ -1,10 +1,13 @@
 <template>
   <button
+    type="button"
+    data-testid="reshuffle"
     @click="handleReshuffle"
     class="btn btn-primary btn-md rounded-full flex items-center gap-1 sm:gap-2 transition-all duration-300 whitespace-nowrap"
     :title="tooltip"
+    :aria-label="tooltip"
   >
-    <span class="text-base sm:text-lg">🔀</span>
+    <span class="text-base sm:text-lg" aria-hidden="true">🔀</span>
     <span class="text-sm sm:text-base hidden md:block">{{ buttonText }}</span>
   </button>
 </template>

--- a/src/stores/global.ts
+++ b/src/stores/global.ts
@@ -1,6 +1,7 @@
 import { computed, ref } from 'vue';
 import { defineStore } from 'pinia';
 import { nextTheme } from '@/utils/theme';
+import { nextShuffleTrigger } from '@/utils/reshuffle';
 
 export const useGlobalStore = defineStore(
   'global',
@@ -30,7 +31,7 @@ export const useGlobalStore = defineStore(
 
     const toggleReshuffle = () => {
       isReshuffled.value = true;
-      shuffleTrigger.value++;
+      shuffleTrigger.value = nextShuffleTrigger(shuffleTrigger.value);
     };
 
     const resetReshuffle = () => {

--- a/src/utils/reshuffle.spec.ts
+++ b/src/utils/reshuffle.spec.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { nextShuffleTrigger } from './reshuffle';
+
+describe('nextShuffleTrigger', () => {
+  it('increments and treats non-finite as zero', () => {
+    expect(nextShuffleTrigger(0)).toBe(1);
+    expect(nextShuffleTrigger(4)).toBe(5);
+    expect(nextShuffleTrigger(Number.NaN)).toBe(1);
+  });
+});

--- a/src/utils/reshuffle.ts
+++ b/src/utils/reshuffle.ts
@@ -1,0 +1,5 @@
+/** Advance shuffle generation counter (wraps at safe int bound). */
+export function nextShuffleTrigger(current: number): number {
+  const n = Number.isFinite(current) ? Math.trunc(current) : 0;
+  return n >= Number.MAX_SAFE_INTEGER - 1 ? 1 : n + 1;
+}


### PR DESCRIPTION
## Summary (agent-invented)
- `nextShuffleTrigger` util + unit tests; pinia reshuffle advances via util.
- Reshuffle button: `type=button`, `aria-label`, `data-testid="reshuffle"`.

## Acceptance
- Unit tests pass; reshuffle control findable in headless.