### PR TITLE
feat(a11y): active filters summary util and live region

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1266,6 +1266,7 @@
     "beginners": "Beginner-friendly",
     "federated": "Federated / protocols",
     "appCount": "Showing {shown} of {total} apps",
+    "activeSummary": "{count} active filters",
     "clear": "Clear filters",
     "starred": "Starred only"
   },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1266,6 +1266,7 @@
     "beginners": "Para principiantes",
     "federated": "Federados / protocolos",
     "appCount": "Mostrando {shown} de {total} apps",
+    "activeSummary": "{count} filtros activos",
     "clear": "Limpiar filtros",
     "starred": "Solo favoritos"
   },

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -1266,6 +1266,7 @@
     "beginners": "Para iniciantes",
     "federated": "Federados / protocolos",
     "appCount": "Mostrando {shown} de {total} apps",
+    "activeSummary": "{count} filtros ativos",
     "clear": "Limpar filtros",
     "starred": "Só favoritos"
   },

--- a/src/utils/activeFilters.spec.ts
+++ b/src/utils/activeFilters.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { countActiveFilters, describeActiveFilters } from './activeFilters';
+import { defaultHomeFilterState } from './homeFilters';
+
+describe('describeActiveFilters', () => {
+  it('returns empty when browsing all defaults', () => {
+    expect(describeActiveFilters(defaultHomeFilterState())).toEqual([]);
+    expect(countActiveFilters(defaultHomeFilterState())).toBe(0);
+  });
+
+  it('lists search, category, useCase, and toggles in stable order', () => {
+    const state = {
+      ...defaultHomeFilterState(),
+      searchQuery: '  mastodon  ',
+      selectedCategory: 'social',
+      selectedUseCase: 'chat',
+      beginnersOnly: true,
+      federatedOnly: true,
+      starredOnly: true,
+    };
+    expect(describeActiveFilters(state)).toEqual([
+      { key: 'search', value: 'mastodon' },
+      { key: 'category', value: 'social' },
+      { key: 'useCase', value: 'chat' },
+      { key: 'beginners' },
+      { key: 'federated' },
+      { key: 'starred' },
+    ]);
+    expect(countActiveFilters(state)).toBe(6);
+  });
+
+  it('ignores whitespace-only search', () => {
+    const state = { ...defaultHomeFilterState(), searchQuery: '   ' };
+    expect(describeActiveFilters(state)).toEqual([]);
+  });
+});

--- a/src/utils/activeFilters.ts
+++ b/src/utils/activeFilters.ts
@@ -1,0 +1,41 @@
+import type { HomeFilterState } from '@/utils/homeFilters';
+
+/** Stable keys for active home constraints (order is display priority). */
+export type ActiveFilterKey =
+  | 'search'
+  | 'category'
+  | 'useCase'
+  | 'beginners'
+  | 'federated'
+  | 'starred';
+
+export type ActiveFilterDescriptor = {
+  key: ActiveFilterKey;
+  /** Raw value for search/category/useCase when applicable. */
+  value?: string;
+};
+
+/**
+ * List active home filters in a stable order for summary chips / a11y live regions.
+ * Pure: no i18n — caller maps keys/values to labels.
+ */
+export function describeActiveFilters(state: HomeFilterState): ActiveFilterDescriptor[] {
+  const out: ActiveFilterDescriptor[] = [];
+  const q = state.searchQuery.trim();
+  if (q) out.push({ key: 'search', value: q });
+  if (state.selectedCategory !== 'all') {
+    out.push({ key: 'category', value: state.selectedCategory });
+  }
+  if (state.selectedUseCase !== 'all') {
+    out.push({ key: 'useCase', value: state.selectedUseCase });
+  }
+  if (state.beginnersOnly) out.push({ key: 'beginners' });
+  if (state.federatedOnly) out.push({ key: 'federated' });
+  if (state.starredOnly) out.push({ key: 'starred' });
+  return out;
+}
+
+/** Count of active constraints (shortcut for badges). */
+export function countActiveFilters(state: HomeFilterState): number {
+  return describeActiveFilters(state).length;
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -17,6 +17,7 @@ import { filterApps, shuffleAppsPurely, sortAppsByLinksThenRandom } from '@/util
 import { getAppSlug } from '@/utils/global';
 import { applyQuickFilters } from '@/utils/quickFilters';
 import { filterStarredOnly, hasActiveHomeFilters } from '@/utils/homeFilters';
+import { countActiveFilters, describeActiveFilters } from '@/utils/activeFilters';
 import { parseSearchQueryParam, withSearchQueryParam } from '@/utils/searchQueryUrl';
 import { currentPageLink } from '@/utils/pageLink';
 import { resolveEscapeAction } from '@/utils/escapeAction';
@@ -106,16 +107,20 @@ function toggleStarredOnly() {
   globalStore.resetReshuffle();
 }
 
-const filtersActive = computed(() =>
-  hasActiveHomeFilters({
-    searchQuery: searchQuery.value,
-    selectedCategory: selectedCategory.value,
-    selectedUseCase: selectedUseCase.value,
-    beginnersOnly: beginnersOnly.value,
-    federatedOnly: federatedOnly.value,
-    starredOnly: starredOnly.value,
-  }),
-);
+const homeFilterState = computed(() => ({
+  searchQuery: searchQuery.value,
+  selectedCategory: selectedCategory.value,
+  selectedUseCase: selectedUseCase.value,
+  beginnersOnly: beginnersOnly.value,
+  federatedOnly: federatedOnly.value,
+  starredOnly: starredOnly.value,
+}));
+
+const filtersActive = computed(() => hasActiveHomeFilters(homeFilterState.value));
+
+const activeFilterDescriptors = computed(() => describeActiveFilters(homeFilterState.value));
+const activeFilterCount = computed(() => countActiveFilters(homeFilterState.value));
+const activeFilterKeys = computed(() => activeFilterDescriptors.value.map((d) => d.key));
 
 function clearAllFilters() {
   searchQuery.value = '';
@@ -424,6 +429,15 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
       aria-live="polite"
     >
       {{ t('filters.appCount', { shown: filteredApps.length, total: apps.length }) }}
+    </p>
+    <p
+      v-if="activeFilterCount > 0"
+      class="text-center text-xs text-base-content/60 mb-2"
+      data-testid="active-filters-summary"
+      aria-live="polite"
+    >
+      {{ t('filters.activeSummary', { count: activeFilterCount }) }}
+      <span class="sr-only">{{ activeFilterKeys.join(', ') }}</span>
     </p>
   </header>
 


### PR DESCRIPTION
## Summary
Invented improvement (empty GH backlog): pure `describeActiveFilters` / `countActiveFilters` helpers plus a polite live region summarizing how many home filters are active.

## Acceptance criteria
- [x] `src/utils/activeFilters.ts` lists active constraints in stable order (search, category, useCase, beginners, federated, starred)
- [x] Unit tests drive the real functions (3 cases)
- [x] HomeView shows `data-testid="active-filters-summary"` when count > 0; i18n en/pt/es `filters.activeSummary`
- [x] Unit + production build pass

## Test plan
- `npm run test:unit -- --run src/utils/activeFilters.spec.ts`
- `npm run build-only`
- Headless: enable beginners chip → summary visible