### PR TITLE
feat(a11y): shared keyboard target guard for global shortcuts

### DIFF
--- a/src/utils/keyboardTarget.spec.ts
+++ b/src/utils/keyboardTarget.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { isEditableTarget, shouldHandleGlobalShortcut } from './keyboardTarget';
+
+function el(tag: string, attrs: Record<string, string> = {}): HTMLElement {
+  const node = document.createElement(tag);
+  for (const [k, v] of Object.entries(attrs)) node.setAttribute(k, v);
+  return node;
+}
+
+describe('isEditableTarget', () => {
+  it('detects input/textarea/select and contentEditable', () => {
+    expect(isEditableTarget(el('INPUT'))).toBe(true);
+    expect(isEditableTarget(el('TEXTAREA'))).toBe(true);
+    expect(isEditableTarget(el('SELECT'))).toBe(true);
+    const div = el('DIV');
+    div.contentEditable = 'true';
+    expect(isEditableTarget(div)).toBe(true);
+    expect(isEditableTarget(el('BUTTON'))).toBe(false);
+    expect(isEditableTarget(null)).toBe(false);
+  });
+
+  it('treats textbox/searchbox/combobox roles as editable', () => {
+    expect(isEditableTarget(el('DIV', { role: 'textbox' }))).toBe(true);
+    expect(isEditableTarget(el('DIV', { role: 'searchbox' }))).toBe(true);
+    expect(isEditableTarget(el('DIV', { role: 'combobox' }))).toBe(true);
+  });
+});
+
+describe('shouldHandleGlobalShortcut', () => {
+  it('blocks ctrl/meta/alt and editable targets', () => {
+    expect(
+      shouldHandleGlobalShortcut({ target: el('BUTTON'), metaKey: false, ctrlKey: false, altKey: false }),
+    ).toBe(true);
+    expect(
+      shouldHandleGlobalShortcut({ target: el('INPUT'), metaKey: false, ctrlKey: false, altKey: false }),
+    ).toBe(false);
+    expect(
+      shouldHandleGlobalShortcut({ target: el('BUTTON'), metaKey: true, ctrlKey: false, altKey: false }),
+    ).toBe(false);
+  });
+});

--- a/src/utils/keyboardTarget.ts
+++ b/src/utils/keyboardTarget.ts
@@ -1,0 +1,23 @@
+/** True when the event target is an editable field — global shortcuts should ignore these. */
+export function isEditableTarget(target: EventTarget | null | undefined): boolean {
+  if (!target || !(target instanceof Element)) return false;
+  const el = target as HTMLElement;
+  const tag = el.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+  if (el.isContentEditable || el.getAttribute('contenteditable') === 'true') return true;
+  // role=textbox / combobox often behave as fields for shortcuts
+  const role = el.getAttribute('role');
+  if (role === 'textbox' || role === 'searchbox' || role === 'combobox') return true;
+  return false;
+}
+
+/**
+ * Whether a global key handler should run for this event.
+ * Skips when modifier chords (except shift for letters) or editable focus.
+ */
+export function shouldHandleGlobalShortcut(
+  event: Pick<KeyboardEvent, 'target' | 'metaKey' | 'ctrlKey' | 'altKey'>,
+): boolean {
+  if (event.metaKey || event.ctrlKey || event.altKey) return false;
+  return !isEditableTarget(event.target);
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -21,6 +21,7 @@ import { countActiveFilters, describeActiveFilters } from '@/utils/activeFilters
 import { parseSearchQueryParam, withSearchQueryParam } from '@/utils/searchQueryUrl';
 import { currentPageLink } from '@/utils/pageLink';
 import { resolveEscapeAction } from '@/utils/escapeAction';
+import { isEditableTarget, shouldHandleGlobalShortcut } from '@/utils/keyboardTarget';
 import {
   clearRecentApps,
   listRecentApps,
@@ -223,12 +224,6 @@ const searchPlaceholder = computed(() =>
 
 const isUpdatingFromURL = ref(false);
 
-function isTypingTarget(el: EventTarget | null): boolean {
-  if (!(el instanceof HTMLElement)) return false;
-  const tag = el.tagName;
-  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || el.isContentEditable;
-}
-
 function focusSearchInput() {
   showFilters.value = true;
   nextTick(() => {
@@ -241,14 +236,9 @@ function focusSearchInput() {
 }
 
 function onGlobalKeydown(e: KeyboardEvent) {
-  if (e.defaultPrevented || e.metaKey || e.ctrlKey || e.altKey) return;
+  if (e.defaultPrevented) return;
 
-  if (e.key === '?' && !isTypingTarget(e.target)) {
-    e.preventDefault();
-    showShortcuts.value = !showShortcuts.value;
-    return;
-  }
-
+  // Esc may clear filters even from search; other chords use the shared guard.
   if (e.key === 'Escape') {
     const action = resolveEscapeAction({
       shortcutsOpen: showShortcuts.value,
@@ -270,7 +260,15 @@ function onGlobalKeydown(e: KeyboardEvent) {
     return;
   }
 
-  if (e.key === '/' && !isTypingTarget(e.target) && !mostrarModal.value && !showShortcuts.value) {
+  if (!shouldHandleGlobalShortcut(e)) return;
+
+  if (e.key === '?' && !isEditableTarget(e.target)) {
+    e.preventDefault();
+    showShortcuts.value = !showShortcuts.value;
+    return;
+  }
+
+  if (e.key === '/' && !isEditableTarget(e.target) && !mostrarModal.value && !showShortcuts.value) {
     e.preventDefault();
     focusSearchInput();
   }


### PR DESCRIPTION
## Summary
Invented (empty backlog): pure `keyboardTarget` helpers for global shortcut gating; HomeView delegates to them.

## Acceptance
- [x] `isEditableTarget` covers input/textarea/select/contentEditable/textbox roles
- [x] `shouldHandleGlobalShortcut` blocks meta/ctrl/alt and editable targets
- [x] HomeView `?` / `/` use the util (Esc still allows clear-from-search)
- [x] Unit tests on real functions; build passes

## Test plan
- `npm run test:unit -- --run src/utils/keyboardTarget.spec.ts`
- `npm run build-only`