### PR TITLE
feat: clipboardCopy util for favorites and page link share

### DIFF
--- a/src/utils/clipboardCopy.spec.ts
+++ b/src/utils/clipboardCopy.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+import { clipboardFeedbackKey, copyTextToClipboard } from './clipboardCopy';
+
+describe('copyTextToClipboard', () => {
+  it('returns empty for blank input without calling write', async () => {
+    const write = vi.fn(async () => {});
+    expect(await copyTextToClipboard('   ', write)).toBe('empty');
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it('returns ok when write resolves', async () => {
+    const write = vi.fn(async () => {});
+    expect(await copyTextToClipboard('hello', write)).toBe('ok');
+    expect(write).toHaveBeenCalledWith('hello');
+  });
+
+  it('returns denied when write rejects', async () => {
+    const write = vi.fn(async () => {
+      throw new Error('nope');
+    });
+    expect(await copyTextToClipboard('x', write)).toBe('denied');
+  });
+});
+
+describe('clipboardFeedbackKey', () => {
+  it('maps results for UI', () => {
+    expect(clipboardFeedbackKey('ok')).toBe('copied');
+    expect(clipboardFeedbackKey('empty')).toBe('empty');
+    expect(clipboardFeedbackKey('denied')).toBe('failed');
+    expect(clipboardFeedbackKey('unsupported')).toBe('failed');
+  });
+});

--- a/src/utils/clipboardCopy.ts
+++ b/src/utils/clipboardCopy.ts
@@ -1,0 +1,34 @@
+/** Result of attempting to write plain text to the clipboard. */
+export type ClipboardWriteResult = 'ok' | 'empty' | 'unsupported' | 'denied';
+
+/**
+ * Write text to the clipboard when available.
+ * Pure decision helper + thin write — pass `write` for tests (default: navigator.clipboard.writeText).
+ */
+export async function copyTextToClipboard(
+  text: string,
+  write: (value: string) => Promise<void> = defaultWrite,
+): Promise<ClipboardWriteResult> {
+  const value = text ?? '';
+  if (!value.trim()) return 'empty';
+  try {
+    await write(value);
+    return 'ok';
+  } catch {
+    return 'denied';
+  }
+}
+
+async function defaultWrite(value: string): Promise<void> {
+  if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
+    throw new Error('unsupported');
+  }
+  await navigator.clipboard.writeText(value);
+}
+
+/** Map write result to a short status key for UI feedback. */
+export function clipboardFeedbackKey(result: ClipboardWriteResult): 'copied' | 'failed' | 'empty' {
+  if (result === 'ok') return 'copied';
+  if (result === 'empty') return 'empty';
+  return 'failed';
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -21,6 +21,7 @@ import { countActiveFilters, describeActiveFilters } from '@/utils/activeFilters
 import { parseSearchQueryParam, withSearchQueryParam } from '@/utils/searchQueryUrl';
 import { currentPageLink } from '@/utils/pageLink';
 import { resolveEscapeAction } from '@/utils/escapeAction';
+import { copyTextToClipboard } from '@/utils/clipboardCopy';
 import { isEditableTarget, shouldHandleGlobalShortcut } from '@/utils/keyboardTarget';
 import {
   clearRecentApps,
@@ -161,11 +162,7 @@ function refreshStarsTick() {
 
 async function onCopyPageLink() {
   const url = currentPageLink(window.location);
-  try {
-    await navigator.clipboard.writeText(url);
-  } catch {
-    /* clipboard may be blocked in some contexts */
-  }
+  await copyTextToClipboard(url);
   pageLinkCopied.value = true;
   window.setTimeout(() => {
     pageLinkCopied.value = false;
@@ -175,11 +172,7 @@ async function onCopyPageLink() {
 async function onExportFavorites() {
   const text = exportStarredAsText(listStarredApps());
   if (!text) return;
-  try {
-    await navigator.clipboard.writeText(text);
-  } catch {
-    /* clipboard may be blocked; still show feedback for headless checks */
-  }
+  await copyTextToClipboard(text);
   favoritesCopied.value = true;
   window.setTimeout(() => {
     favoritesCopied.value = false;


### PR DESCRIPTION
## Summary
Invented (empty GH issues): `copyTextToClipboard` / `clipboardFeedbackKey` with DI for unit tests; HomeView share paths use it.

## Acceptance
- [x] Empty/whitespace text → `empty` without write
- [x] Successful write → `ok`; rejection → `denied`
- [x] HomeView page link + favorites export call the util
- [x] Unit tests pass; production build passes

## Test plan
- `npm run test:unit -- --run src/utils/clipboardCopy.spec.ts`
- `npm run build-only`