### PR TITLE
feat: debounce util and search debounce constant on home

### DIFF
--- a/src/utils/debounce.spec.ts
+++ b/src/utils/debounce.spec.ts
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { debounce, normalizeDebounceMs } from './debounce';
+
+describe('normalizeDebounceMs', () => {
+  it('falls back and clamps', () => {
+    expect(normalizeDebounceMs(NaN)).toBe(200);
+    expect(normalizeDebounceMs(-1)).toBe(200);
+    expect(normalizeDebounceMs(150)).toBe(150);
+    expect(normalizeDebounceMs(99999)).toBe(5000);
+  });
+});
+
+describe('debounce', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('invokes once after quiet period with latest args', () => {
+    const fn = vi.fn();
+    const d = debounce(fn, 100);
+    d('a');
+    d('b');
+    expect(fn).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(100);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith('b');
+  });
+
+  it('cancel prevents invocation', () => {
+    const fn = vi.fn();
+    const d = debounce(fn, 50);
+    d(1);
+    d.cancel();
+    vi.advanceTimersByTime(50);
+    expect(fn).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,0 +1,48 @@
+/** Schedule `fn` to run after `waitMs` of quiet; returns cancel+flush helpers. */
+export type DebouncedFn<Args extends unknown[]> = ((...args: Args) => void) & {
+  cancel: () => void;
+  flush: (...args: Args) => void;
+};
+
+export function debounce<Args extends unknown[]>(
+  fn: (...args: Args) => void,
+  waitMs: number,
+): DebouncedFn<Args> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let lastArgs: Args | null = null;
+
+  const cancel = () => {
+    if (timer != null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  const run = (args: Args) => {
+    lastArgs = null;
+    fn(...args);
+  };
+
+  const wrapped = ((...args: Args) => {
+    lastArgs = args;
+    cancel();
+    timer = setTimeout(() => {
+      timer = null;
+      if (lastArgs) run(lastArgs);
+    }, waitMs);
+  }) as DebouncedFn<Args>;
+
+  wrapped.cancel = cancel;
+  wrapped.flush = (...args: Args) => {
+    cancel();
+    run(args.length ? args : (lastArgs ?? ([] as unknown as Args)));
+  };
+
+  return wrapped;
+}
+
+/** Clamp debounce wait to a sensible UI range (ms). */
+export function normalizeDebounceMs(ms: number, fallback = 200): number {
+  if (!Number.isFinite(ms) || ms < 0) return fallback;
+  return Math.min(Math.floor(ms), 5000);
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -19,6 +19,7 @@ import { applyQuickFilters } from '@/utils/quickFilters';
 import { filterStarredOnly, hasActiveHomeFilters } from '@/utils/homeFilters';
 import { countActiveFilters, describeActiveFilters } from '@/utils/activeFilters';
 import { parseSearchQueryParam, withSearchQueryParam } from '@/utils/searchQueryUrl';
+import { debounce, normalizeDebounceMs } from '@/utils/debounce';
 import { currentPageLink } from '@/utils/pageLink';
 import { resolveEscapeAction } from '@/utils/escapeAction';
 import { copyTextToClipboard } from '@/utils/clipboardCopy';
@@ -49,6 +50,8 @@ const { apps } = useApps();
 
 const modalData = ref<Partial<App>>({});
 const searchQuery = ref('');
+const SEARCH_DEBOUNCE_MS = normalizeDebounceMs(250);
+
 const selectedCategory = ref<CategoryId>('all');
 const selectedUseCase = ref<UseCaseId | 'all'>('all');
 const showFilters = ref(false);
@@ -417,6 +420,7 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
     <p
       class="text-center text-sm text-base-content/70 mb-3"
       data-testid="app-count-badge"
+      :data-search-debounce-ms="SEARCH_DEBOUNCE_MS"
       aria-live="polite"
     >
       {{ t('filters.appCount', { shown: filteredApps.length, total: apps.length }) }}


### PR DESCRIPTION
## Summary
Invented (empty issues): pure `debounce` / `normalizeDebounceMs` for UI timing; HomeView records normalized search debounce ms.

## Acceptance
- [x] debounce invokes once with latest args after wait; cancel works
- [x] normalizeDebounceMs fallbacks and clamps to 5000
- [x] Unit tests pass; build passes

## Test plan
- `npm run test:unit -- --run src/utils/debounce.spec.ts`
- `npm run build-only`