### PR TITLE
feat: classNames/cx helper for conditional CSS tokens

### DIFF
--- a/src/utils/classNames.spec.ts
+++ b/src/utils/classNames.spec.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { classNames, cx } from './classNames';
+
+describe('classNames', () => {
+  it('joins truthy tokens and skips falsey', () => {
+    expect(classNames('a', false && 'b', 'c')).toBe('a c');
+    expect(classNames('  x  ', null, undefined, 0 as unknown as string)).toBe('x');
+    expect(classNames(['a', ['b', false, 'c']])).toBe('a b c');
+    expect(cx('btn', true && 'btn-primary')).toBe('btn btn-primary');
+  });
+});

--- a/src/utils/classNames.ts
+++ b/src/utils/classNames.ts
@@ -1,0 +1,22 @@
+type ClassValue = string | false | null | undefined | 0 | ClassValue[];
+
+/** Join truthy class tokens (strings / nested arrays); skips falsey entries. */
+export function classNames(...parts: ClassValue[]): string {
+  const out: string[] = [];
+  const walk = (v: ClassValue) => {
+    if (!v) return;
+    if (Array.isArray(v)) {
+      for (const item of v) walk(item);
+      return;
+    }
+    if (typeof v === 'string') {
+      const t = v.trim();
+      if (t) out.push(t);
+    }
+  };
+  for (const p of parts) walk(p);
+  return out.join(' ');
+}
+
+/** Alias used by some codebases. */
+export const cx = classNames;

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -22,6 +22,7 @@ import { parseSearchQueryParam, withSearchQueryParam } from '@/utils/searchQuery
 import { debounce, normalizeDebounceMs } from '@/utils/debounce';
 import { storageKey } from '@/utils/storageKey';
 import { safeJsonParse } from '@/utils/safeJson';
+import { classNames } from '@/utils/classNames';
 import { currentPageLink } from '@/utils/pageLink';
 import { resolveEscapeAction } from '@/utils/escapeAction';
 import { copyTextToClipboard } from '@/utils/clipboardCopy';
@@ -481,8 +482,7 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
     >
       <button
         type="button"
-        class="btn btn-sm"
-        :class="beginnersOnly ? 'btn-primary' : 'btn-outline'"
+        :class="classNames('btn', 'btn-sm', beginnersOnly ? 'btn-primary' : 'btn-outline')"
         data-testid="chip-beginners"
         :aria-pressed="beginnersOnly"
         @click="toggleBeginnersOnly"


### PR DESCRIPTION
## Summary
Invented: `classNames` / `cx` for building class strings; beginners filter chip uses it.

## Acceptance
- [x] Skips falsey; flattens nested arrays; trims tokens
- [x] Unit + build pass

## Test plan
- `npm run test:unit -- --run src/utils/classNames.spec.ts`