### PR TITLE
feat: clamp and clampIndex numeric helpers

### DIFF
--- a/src/utils/clamp.spec.ts
+++ b/src/utils/clamp.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { clamp, clampIndex } from './clamp';
+
+describe('clamp', () => {
+  it('bounds and swaps min/max', () => {
+    expect(clamp(5, 0, 10)).toBe(5);
+    expect(clamp(-1, 0, 10)).toBe(0);
+    expect(clamp(99, 0, 10)).toBe(10);
+    expect(clamp(3, 10, 0)).toBe(3);
+    expect(clamp(NaN, 2, 4)).toBe(2);
+  });
+});
+
+describe('clampIndex', () => {
+  it('indexes into list length', () => {
+    expect(clampIndex(2, 5)).toBe(2);
+    expect(clampIndex(-3, 5)).toBe(0);
+    expect(clampIndex(9, 5)).toBe(4);
+    expect(clampIndex(1, 0)).toBe(0);
+  });
+});

--- a/src/utils/clamp.ts
+++ b/src/utils/clamp.ts
@@ -1,0 +1,13 @@
+/** Constrain `n` to inclusive [min, max]. Non-finite input uses min. */
+export function clamp(n: number, min: number, max: number): number {
+  const lo = Math.min(min, max);
+  const hi = Math.max(min, max);
+  if (!Number.isFinite(n)) return lo;
+  return Math.min(hi, Math.max(lo, n));
+}
+
+/** Clamp an integer index into `0 .. length-1` (empty → 0). */
+export function clampIndex(index: number, length: number): number {
+  if (!Number.isFinite(length) || length <= 0) return 0;
+  return clamp(Math.trunc(index), 0, length - 1);
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -23,6 +23,7 @@ import { debounce, normalizeDebounceMs } from '@/utils/debounce';
 import { storageKey } from '@/utils/storageKey';
 import { safeJsonParse } from '@/utils/safeJson';
 import { classNames } from '@/utils/classNames';
+import { clampIndex } from '@/utils/clamp';
 import { currentPageLink } from '@/utils/pageLink';
 import { resolveEscapeAction } from '@/utils/escapeAction';
 import { copyTextToClipboard } from '@/utils/clipboardCopy';
@@ -56,6 +57,8 @@ const searchQuery = ref('');
 const SEARCH_DEBOUNCE_MS = normalizeDebounceMs(250);
 const STORAGE_RECENT_KEY = storageKey('recent', 'apps');
 const SAFE_JSON_PROBE = safeJsonParse('[]', [] as string[]);
+const CLAMP_IDX_PROBE = clampIndex(1, 3);
+
 
 
 
@@ -427,6 +430,7 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
     <p
       class="text-center text-sm text-base-content/70 mb-3"
       data-testid="app-count-badge"
+      :data-clamp-idx-probe="CLAMP_IDX_PROBE"
       :data-safe-json-probe-len="SAFE_JSON_PROBE.length"
       :data-storage-recent-key="STORAGE_RECENT_KEY"
       :data-search-debounce-ms="SEARCH_DEBOUNCE_MS"


### PR DESCRIPTION
## Summary
Invented: `clamp` / `clampIndex` for safe numeric bounds.

## Acceptance
- [x] Inclusive range clamp; min/max order independent
- [x] clampIndex for list positions; empty length → 0
- [x] Unit + build pass

## Test plan
- `npm run test:unit -- --run src/utils/clamp.spec.ts`