### PR TITLE
feat: truncateText helper for compact UI labels

### DIFF
--- a/src/utils/truncateText.spec.ts
+++ b/src/utils/truncateText.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { needsTruncation, truncateText } from './truncateText';
+
+describe('truncateText', () => {
+  it('leaves short strings and truncates long ones', () => {
+    expect(truncateText('hello', 10)).toBe('hello');
+    expect(truncateText('hello world', 8)).toBe('hello w…');
+    expect(truncateText('abc', 0)).toBe('');
+  });
+});
+
+describe('needsTruncation', () => {
+  it('detects when limit is exceeded', () => {
+    expect(needsTruncation('abcd', 3)).toBe(true);
+    expect(needsTruncation('ab', 3)).toBe(false);
+  });
+});

--- a/src/utils/truncateText.ts
+++ b/src/utils/truncateText.ts
@@ -1,0 +1,13 @@
+/** Truncate `text` to at most `maxLen` chars, appending `ellipsis` when shortened. */
+export function truncateText(text: string, maxLen: number, ellipsis = '…'): string {
+  const s = text ?? '';
+  if (!Number.isFinite(maxLen) || maxLen <= 0) return '';
+  if (s.length <= maxLen) return s;
+  const cut = Math.max(0, maxLen - ellipsis.length);
+  return s.slice(0, cut) + ellipsis;
+}
+
+/** True when truncation would change the string for the given limit. */
+export function needsTruncation(text: string, maxLen: number): boolean {
+  return (text ?? '').length > maxLen && Number.isFinite(maxLen) && maxLen >= 0;
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -25,6 +25,7 @@ import { safeJsonParse } from '@/utils/safeJson';
 import { classNames } from '@/utils/classNames';
 import { clampIndex } from '@/utils/clamp';
 import { uniqueStrings } from '@/utils/uniqueBy';
+import { truncateText } from '@/utils/truncateText';
 import { currentPageLink } from '@/utils/pageLink';
 import { resolveEscapeAction } from '@/utils/escapeAction';
 import { copyTextToClipboard } from '@/utils/clipboardCopy';
@@ -60,6 +61,8 @@ const STORAGE_RECENT_KEY = storageKey('recent', 'apps');
 const SAFE_JSON_PROBE = safeJsonParse('[]', [] as string[]);
 const CLAMP_IDX_PROBE = clampIndex(1, 3);
 const UNIQUE_PROBE = uniqueStrings(['a', 'a', 'b']).length;
+const TRUNC_PROBE = truncateText('abcdefghij', 6);
+
 
 
 
@@ -433,6 +436,7 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
     <p
       class="text-center text-sm text-base-content/70 mb-3"
       data-testid="app-count-badge"
+      :data-trunc-probe="TRUNC_PROBE"
       :data-unique-probe="UNIQUE_PROBE"
       :data-clamp-idx-probe="CLAMP_IDX_PROBE"
       :data-safe-json-probe-len="SAFE_JSON_PROBE.length"


### PR DESCRIPTION
## Summary
Invented: `truncateText` / `needsTruncation` for chip/title ellipsis.

## Acceptance
- [x] Respects maxLen and ellipsis width
- [x] Unit + build pass

## Test plan
- `npm run test:unit -- --run src/utils/truncateText.spec.ts`