### PR TITLE
feat: range and indices helpers for list iteration

### DIFF
--- a/src/utils/range.spec.ts
+++ b/src/utils/range.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { indices, range } from './range';
+
+describe('range', () => {
+  it('builds ascending and descending inclusive ranges', () => {
+    expect(range(1, 3)).toEqual([1, 2, 3]);
+    expect(range(3, 1)).toEqual([3, 2, 1]);
+    expect(range(2, 2)).toEqual([2]);
+  });
+});
+
+describe('indices', () => {
+  it('lists zero-based indices', () => {
+    expect(indices(3)).toEqual([0, 1, 2]);
+    expect(indices(0)).toEqual([]);
+  });
+});

--- a/src/utils/range.ts
+++ b/src/utils/range.ts
@@ -1,0 +1,17 @@
+/** Inclusive integer range from `start` to `end` (direction-aware). Caps length at 10_000. */
+export function range(start: number, end: number): number[] {
+  const a = Math.trunc(start);
+  const b = Math.trunc(end);
+  const step = a <= b ? 1 : -1;
+  const len = Math.min(Math.abs(b - a) + 1, 10_000);
+  const out = new Array<number>(len);
+  for (let i = 0; i < len; i++) out[i] = a + i * step;
+  return out;
+}
+
+/** Zero-based indices `0 .. count-1` (empty if count <= 0). */
+export function indices(count: number): number[] {
+  const n = Math.trunc(count);
+  if (!Number.isFinite(n) || n <= 0) return [];
+  return range(0, n - 1);
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -26,6 +26,7 @@ import { classNames } from '@/utils/classNames';
 import { clampIndex } from '@/utils/clamp';
 import { uniqueStrings } from '@/utils/uniqueBy';
 import { truncateText } from '@/utils/truncateText';
+import { indices } from '@/utils/range';
 import { currentPageLink } from '@/utils/pageLink';
 import { resolveEscapeAction } from '@/utils/escapeAction';
 import { copyTextToClipboard } from '@/utils/clipboardCopy';
@@ -62,6 +63,8 @@ const SAFE_JSON_PROBE = safeJsonParse('[]', [] as string[]);
 const CLAMP_IDX_PROBE = clampIndex(1, 3);
 const UNIQUE_PROBE = uniqueStrings(['a', 'a', 'b']).length;
 const TRUNC_PROBE = truncateText('abcdefghij', 6);
+const RANGE_PROBE = indices(3).length;
+
 
 
 
@@ -436,6 +439,7 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
     <p
       class="text-center text-sm text-base-content/70 mb-3"
       data-testid="app-count-badge"
+      :data-range-probe="RANGE_PROBE"
       :data-trunc-probe="TRUNC_PROBE"
       :data-unique-probe="UNIQUE_PROBE"
       :data-clamp-idx-probe="CLAMP_IDX_PROBE"


### PR DESCRIPTION
## Summary
Invented: `range` / `indices` for inclusive integer sequences.

## Acceptance
- [x] Ascending/descending inclusive range; indices for counts
- [x] Unit + build pass

## Test plan
- `npm run test:unit -- --run src/utils/range.spec.ts`