### PR TITLE
feat: groupBy helpers for categorizing app lists

### DIFF
--- a/src/utils/groupBy.spec.ts
+++ b/src/utils/groupBy.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { groupBy, groupByRecord } from './groupBy';
+
+describe('groupBy', () => {
+  it('buckets by key preserving order within groups', () => {
+    const items = [
+      { c: 'a', n: 1 },
+      { c: 'b', n: 2 },
+      { c: 'a', n: 3 },
+    ];
+    const m = groupBy(items, (i) => i.c);
+    expect([...m.keys()]).toEqual(['a', 'b']);
+    expect(m.get('a')?.map((x) => x.n)).toEqual([1, 3]);
+  });
+});
+
+describe('groupByRecord', () => {
+  it('returns plain object buckets', () => {
+    expect(groupByRecord([{ t: 'x' }, { t: 'x' }], (i) => i.t).x).toHaveLength(2);
+  });
+});

--- a/src/utils/groupBy.ts
+++ b/src/utils/groupBy.ts
@@ -1,0 +1,18 @@
+/** Group items by string key; preserves first-seen key order in returned Map. */
+export function groupBy<T>(items: readonly T[], keyOf: (item: T) => string): Map<string, T[]> {
+  const map = new Map<string, T[]>();
+  for (const item of items) {
+    const k = keyOf(item);
+    const bucket = map.get(k);
+    if (bucket) bucket.push(item);
+    else map.set(k, [item]);
+  }
+  return map;
+}
+
+/** Same as groupBy but returns a plain object (keys insertion-ordered in modern engines). */
+export function groupByRecord<T>(items: readonly T[], keyOf: (item: T) => string): Record<string, T[]> {
+  const out: Record<string, T[]> = {};
+  for (const [k, v] of groupBy(items, keyOf)) out[k] = v;
+  return out;
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -27,6 +27,7 @@ import { clampIndex } from '@/utils/clamp';
 import { uniqueStrings } from '@/utils/uniqueBy';
 import { truncateText } from '@/utils/truncateText';
 import { indices } from '@/utils/range';
+import { groupByRecord } from '@/utils/groupBy';
 import { currentPageLink } from '@/utils/pageLink';
 import { resolveEscapeAction } from '@/utils/escapeAction';
 import { copyTextToClipboard } from '@/utils/clipboardCopy';
@@ -64,6 +65,8 @@ const CLAMP_IDX_PROBE = clampIndex(1, 3);
 const UNIQUE_PROBE = uniqueStrings(['a', 'a', 'b']).length;
 const TRUNC_PROBE = truncateText('abcdefghij', 6);
 const RANGE_PROBE = indices(3).length;
+const GROUP_PROBE = Object.keys(groupByRecord([{k:'a'},{k:'b'}], (x) => x.k)).length;
+
 
 
 
@@ -439,6 +442,7 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
     <p
       class="text-center text-sm text-base-content/70 mb-3"
       data-testid="app-count-badge"
+      :data-group-probe="GROUP_PROBE"
       :data-range-probe="RANGE_PROBE"
       :data-trunc-probe="TRUNC_PROBE"
       :data-unique-probe="UNIQUE_PROBE"


### PR DESCRIPTION
## Summary
Invented: `groupBy` / `groupByRecord` for stable key bucketing (category views).

## Acceptance
- [x] Map preserves first-seen key order; record variant available
- [x] Unit + build pass

## Test plan
- `npm run test:unit -- --run src/utils/groupBy.spec.ts`