### PR TITLE
feat: slugify helper for app and route friendly ids

### DIFF
--- a/src/utils/slugify.spec.ts
+++ b/src/utils/slugify.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { isSlug, slugify } from './slugify';
+
+describe('slugify', () => {
+  it('normalizes text to hyphen slugs', () => {
+    expect(slugify('Hello World')).toBe('hello-world');
+    expect(slugify('  Foo--Bar!! ')).toBe('foo-bar');
+    expect(slugify('Café')).toBe('cafe');
+  });
+});
+
+describe('isSlug', () => {
+  it('validates simple slugs', () => {
+    expect(isSlug('hello-world')).toBe(true);
+    expect(isSlug('Hello')).toBe(false);
+    expect(isSlug('-x')).toBe(false);
+  });
+});

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -1,0 +1,15 @@
+/** URL/app-slug friendly string: lower, ascii-ish, hyphen-separated. */
+export function slugify(input: string): string {
+  return String(input ?? '')
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-{2,}/g, '-');
+}
+
+/** True when already a clean slug (a-z0-9 and single hyphens, no edges). */
+export function isSlug(value: string): boolean {
+  return /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value);
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -28,6 +28,7 @@ import { uniqueStrings } from '@/utils/uniqueBy';
 import { truncateText } from '@/utils/truncateText';
 import { indices } from '@/utils/range';
 import { groupByRecord } from '@/utils/groupBy';
+import { slugify } from '@/utils/slugify';
 import { currentPageLink } from '@/utils/pageLink';
 import { resolveEscapeAction } from '@/utils/escapeAction';
 import { copyTextToClipboard } from '@/utils/clipboardCopy';
@@ -66,6 +67,8 @@ const UNIQUE_PROBE = uniqueStrings(['a', 'a', 'b']).length;
 const TRUNC_PROBE = truncateText('abcdefghij', 6);
 const RANGE_PROBE = indices(3).length;
 const GROUP_PROBE = Object.keys(groupByRecord([{k:'a'},{k:'b'}], (x) => x.k)).length;
+const SLUG_PROBE = slugify('Hello World');
+
 
 
 
@@ -442,6 +445,7 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
     <p
       class="text-center text-sm text-base-content/70 mb-3"
       data-testid="app-count-badge"
+      :data-slug-probe="SLUG_PROBE"
       :data-group-probe="GROUP_PROBE"
       :data-range-probe="RANGE_PROBE"
       :data-trunc-probe="TRUNC_PROBE"


### PR DESCRIPTION
## Summary
Invented: `slugify` / `isSlug` for URL-safe app identifiers.

## Acceptance
- [x] Lowercase hyphen slugs; diacritics stripped
- [x] Unit + build pass

## Test plan
- `npm run test:unit -- --run src/utils/slugify.spec.ts`