### PR TITLE
feat: pickKeys and omitKeys object helpers

### DIFF
--- a/src/utils/pickKeys.spec.ts
+++ b/src/utils/pickKeys.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { omitKeys, pickKeys } from './pickKeys';
+
+describe('pickKeys', () => {
+  it('selects only requested own keys', () => {
+    expect(pickKeys({ a: 1, b: 2, c: 3 }, ['a', 'c'])).toEqual({ a: 1, c: 3 });
+  });
+});
+
+describe('omitKeys', () => {
+  it('removes listed keys', () => {
+    expect(omitKeys({ a: 1, b: 2 }, ['b'])).toEqual({ a: 1 });
+  });
+});

--- a/src/utils/pickKeys.ts
+++ b/src/utils/pickKeys.ts
@@ -1,0 +1,18 @@
+/** Shallow pick listed keys from an object (missing keys omitted). */
+export function pickKeys<T extends object, K extends keyof T>(obj: T, keys: readonly K[]): Pick<T, K> {
+  const out = {} as Pick<T, K>;
+  for (const k of keys) {
+    if (Object.prototype.hasOwnProperty.call(obj, k)) {
+      out[k] = obj[k];
+    }
+  }
+  return out;
+}
+
+/** Shallow omit listed keys from an object. */
+export function omitKeys<T extends object, K extends keyof T>(obj: T, keys: readonly K[]): Omit<T, K> {
+  const skip = new Set<PropertyKey>(keys as readonly PropertyKey[]);
+  const out = { ...obj } as T;
+  for (const k of skip) delete (out as Record<PropertyKey, unknown>)[k];
+  return out as Omit<T, K>;
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -29,6 +29,7 @@ import { truncateText } from '@/utils/truncateText';
 import { indices } from '@/utils/range';
 import { groupByRecord } from '@/utils/groupBy';
 import { slugify } from '@/utils/slugify';
+import { pickKeys } from '@/utils/pickKeys';
 import { currentPageLink } from '@/utils/pageLink';
 import { resolveEscapeAction } from '@/utils/escapeAction';
 import { copyTextToClipboard } from '@/utils/clipboardCopy';
@@ -68,6 +69,8 @@ const TRUNC_PROBE = truncateText('abcdefghij', 6);
 const RANGE_PROBE = indices(3).length;
 const GROUP_PROBE = Object.keys(groupByRecord([{k:'a'},{k:'b'}], (x) => x.k)).length;
 const SLUG_PROBE = slugify('Hello World');
+const PICK_PROBE = Object.keys(pickKeys({ a: 1, b: 2 }, ['a'])).length;
+
 
 
 
@@ -445,6 +448,7 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
     <p
       class="text-center text-sm text-base-content/70 mb-3"
       data-testid="app-count-badge"
+      :data-pick-probe="PICK_PROBE"
       :data-slug-probe="SLUG_PROBE"
       :data-group-probe="GROUP_PROBE"
       :data-range-probe="RANGE_PROBE"


### PR DESCRIPTION
## Summary
Invented: `pickKeys` / `omitKeys` for shallow object projections (query/app payloads).

## Acceptance
- [x] Picks only own requested keys; omit removes listed keys
- [x] Unit + build pass

## Test plan
- `npm run test:unit -- --run src/utils/pickKeys.spec.ts`