### PR TITLE
feat: ensurePrefix/ensureSuffix string affix helpers

### DIFF
--- a/src/utils/ensureAffix.spec.ts
+++ b/src/utils/ensureAffix.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { ensurePrefix, ensureSuffix } from './ensureAffix';
+
+describe('ensurePrefix', () => {
+  it('adds only when missing', () => {
+    expect(ensurePrefix('guia', 'https://')).toBe('https://guia');
+    expect(ensurePrefix('https://x', 'https://')).toBe('https://x');
+  });
+});
+
+describe('ensureSuffix', () => {
+  it('adds only when missing', () => {
+    expect(ensureSuffix('file', '.json')).toBe('file.json');
+    expect(ensureSuffix('a.json', '.json')).toBe('a.json');
+  });
+});

--- a/src/utils/ensureAffix.ts
+++ b/src/utils/ensureAffix.ts
@@ -1,0 +1,15 @@
+/** Ensure `text` starts with `prefix` (no double-prefix). */
+export function ensurePrefix(text: string, prefix: string): string {
+  const s = text ?? '';
+  const p = prefix ?? '';
+  if (!p) return s;
+  return s.startsWith(p) ? s : p + s;
+}
+
+/** Ensure `text` ends with `suffix` (no double-suffix). */
+export function ensureSuffix(text: string, suffix: string): string {
+  const s = text ?? '';
+  const x = suffix ?? '';
+  if (!x) return s;
+  return s.endsWith(x) ? s : s + x;
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -30,6 +30,7 @@ import { indices } from '@/utils/range';
 import { groupByRecord } from '@/utils/groupBy';
 import { slugify } from '@/utils/slugify';
 import { pickKeys } from '@/utils/pickKeys';
+import { ensurePrefix } from '@/utils/ensureAffix';
 import { currentPageLink } from '@/utils/pageLink';
 import { resolveEscapeAction } from '@/utils/escapeAction';
 import { copyTextToClipboard } from '@/utils/clipboardCopy';
@@ -70,6 +71,8 @@ const RANGE_PROBE = indices(3).length;
 const GROUP_PROBE = Object.keys(groupByRecord([{k:'a'},{k:'b'}], (x) => x.k)).length;
 const SLUG_PROBE = slugify('Hello World');
 const PICK_PROBE = Object.keys(pickKeys({ a: 1, b: 2 }, ['a'])).length;
+const AFFIX_PROBE = ensurePrefix('x', '#');
+
 
 
 
@@ -448,6 +451,7 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
     <p
       class="text-center text-sm text-base-content/70 mb-3"
       data-testid="app-count-badge"
+      :data-affix-probe="AFFIX_PROBE"
       :data-pick-probe="PICK_PROBE"
       :data-slug-probe="SLUG_PROBE"
       :data-group-probe="GROUP_PROBE"


### PR DESCRIPTION
## Summary
Invented: `ensurePrefix` / `ensureSuffix` for stable URL/path affixes.

## Acceptance
- [x] Adds affix only when missing
- [x] Unit + build pass

## Test plan
- `npm run test:unit -- --run src/utils/ensureAffix.spec.ts`