### PR TITLE
feat: partition helper to split lists by predicate

### DIFF
--- a/src/utils/partition.spec.ts
+++ b/src/utils/partition.spec.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { partition } from './partition';
+
+describe('partition', () => {
+  it('splits by predicate keeping order', () => {
+    const [evens, odds] = partition([1, 2, 3, 4], (n) => n % 2 === 0);
+    expect(evens).toEqual([2, 4]);
+    expect(odds).toEqual([1, 3]);
+  });
+});

--- a/src/utils/partition.ts
+++ b/src/utils/partition.ts
@@ -1,0 +1,10 @@
+/** Split `items` into [pass, fail] preserving relative order in each. */
+export function partition<T>(items: readonly T[], pred: (item: T, index: number) => boolean): [T[], T[]] {
+  const pass: T[] = [];
+  const fail: T[] = [];
+  items.forEach((item, i) => {
+    if (pred(item, i)) pass.push(item);
+    else fail.push(item);
+  });
+  return [pass, fail];
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -31,6 +31,7 @@ import { groupByRecord } from '@/utils/groupBy';
 import { slugify } from '@/utils/slugify';
 import { pickKeys } from '@/utils/pickKeys';
 import { ensurePrefix } from '@/utils/ensureAffix';
+import { partition } from '@/utils/partition';
 import { currentPageLink } from '@/utils/pageLink';
 import { resolveEscapeAction } from '@/utils/escapeAction';
 import { copyTextToClipboard } from '@/utils/clipboardCopy';
@@ -72,6 +73,8 @@ const GROUP_PROBE = Object.keys(groupByRecord([{k:'a'},{k:'b'}], (x) => x.k)).le
 const SLUG_PROBE = slugify('Hello World');
 const PICK_PROBE = Object.keys(pickKeys({ a: 1, b: 2 }, ['a'])).length;
 const AFFIX_PROBE = ensurePrefix('x', '#');
+const PART_PROBE = partition([1, 2, 3], (n) => n > 1)[0].length;
+
 
 
 
@@ -451,6 +454,7 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
     <p
       class="text-center text-sm text-base-content/70 mb-3"
       data-testid="app-count-badge"
+      :data-part-probe="PART_PROBE"
       :data-affix-probe="AFFIX_PROBE"
       :data-pick-probe="PICK_PROBE"
       :data-slug-probe="SLUG_PROBE"


### PR DESCRIPTION
## Summary
Invented: `partition` for splitting app lists (e.g. starred vs unstarred) while preserving order.

## Acceptance
- [x] Returns [pass, fail] with stable order
- [x] Unit + build pass

## Test plan
- `npm run test:unit -- --run src/utils/partition.spec.ts`