### PR TITLE
feat: countBy and countWhere list tally helpers

### DIFF
--- a/src/utils/countBy.spec.ts
+++ b/src/utils/countBy.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { countBy, countWhere } from './countBy';
+
+describe('countBy', () => {
+  it('tallies keys', () => {
+    const m = countBy(['a', 'b', 'a'], (s) => s);
+    expect(m.get('a')).toBe(2);
+    expect(m.get('b')).toBe(1);
+  });
+});
+
+describe('countWhere', () => {
+  it('counts predicate hits', () => {
+    expect(countWhere([1, 2, 3, 4], (n) => n > 2)).toBe(2);
+  });
+});

--- a/src/utils/countBy.ts
+++ b/src/utils/countBy.ts
@@ -1,0 +1,16 @@
+/** Count items per key; returns Map with insertion order of first key sighting. */
+export function countBy<T>(items: readonly T[], keyOf: (item: T) => string): Map<string, number> {
+  const map = new Map<string, number>();
+  for (const item of items) {
+    const k = keyOf(item);
+    map.set(k, (map.get(k) ?? 0) + 1);
+  }
+  return map;
+}
+
+/** Count how many items satisfy `pred`. */
+export function countWhere<T>(items: readonly T[], pred: (item: T) => boolean): number {
+  let n = 0;
+  for (const item of items) if (pred(item)) n += 1;
+  return n;
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -32,6 +32,7 @@ import { slugify } from '@/utils/slugify';
 import { pickKeys } from '@/utils/pickKeys';
 import { ensurePrefix } from '@/utils/ensureAffix';
 import { partition } from '@/utils/partition';
+import { countWhere } from '@/utils/countBy';
 import { currentPageLink } from '@/utils/pageLink';
 import { resolveEscapeAction } from '@/utils/escapeAction';
 import { copyTextToClipboard } from '@/utils/clipboardCopy';
@@ -74,6 +75,8 @@ const SLUG_PROBE = slugify('Hello World');
 const PICK_PROBE = Object.keys(pickKeys({ a: 1, b: 2 }, ['a'])).length;
 const AFFIX_PROBE = ensurePrefix('x', '#');
 const PART_PROBE = partition([1, 2, 3], (n) => n > 1)[0].length;
+const COUNT_PROBE = countWhere([1, 2, 3], (n) => n >= 2);
+
 
 
 
@@ -454,6 +457,7 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
     <p
       class="text-center text-sm text-base-content/70 mb-3"
       data-testid="app-count-badge"
+      :data-count-probe="COUNT_PROBE"
       :data-part-probe="PART_PROBE"
       :data-affix-probe="AFFIX_PROBE"
       :data-pick-probe="PICK_PROBE"


### PR DESCRIPTION
## Summary
Invented: `countBy` / `countWhere` for app/category tallies.

## Acceptance
- [x] Map tallies by key; countWhere uses predicate
- [x] Unit + build pass

## Test plan
- `npm run test:unit -- --run src/utils/countBy.spec.ts`