### PR TITLE
feat: capitalize and titleCase display helpers

### DIFF
--- a/src/utils/titleCase.spec.ts
+++ b/src/utils/titleCase.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { capitalize, titleCase } from './titleCase';
+
+describe('capitalize', () => {
+  it('uppercases first char only', () => {
+    expect(capitalize('hello')).toBe('Hello');
+    expect(capitalize('')).toBe('');
+  });
+});
+
+describe('titleCase', () => {
+  it('titles spaced and hyphenated words', () => {
+    expect(titleCase('hello world')).toBe('Hello World');
+    expect(titleCase('foo-bar_baz')).toBe('Foo-Bar_Baz');
+  });
+});

--- a/src/utils/titleCase.ts
+++ b/src/utils/titleCase.ts
@@ -1,0 +1,14 @@
+/** Uppercase first character; rest unchanged (locale-safe via toLocaleUpperCase default). */
+export function capitalize(text: string): string {
+  const s = text ?? '';
+  if (!s) return s;
+  return s.charAt(0).toLocaleUpperCase() + s.slice(1);
+}
+
+/** Title-case words separated by spaces/hyphens/underscores. */
+export function titleCase(text: string): string {
+  return String(text ?? '')
+    .split(/([\s_-]+)/)
+    .map((part, i) => (i % 2 === 0 ? capitalize(part.toLocaleLowerCase()) : part))
+    .join('');
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -33,6 +33,7 @@ import { pickKeys } from '@/utils/pickKeys';
 import { ensurePrefix } from '@/utils/ensureAffix';
 import { partition } from '@/utils/partition';
 import { countWhere } from '@/utils/countBy';
+import { titleCase } from '@/utils/titleCase';
 import { currentPageLink } from '@/utils/pageLink';
 import { resolveEscapeAction } from '@/utils/escapeAction';
 import { copyTextToClipboard } from '@/utils/clipboardCopy';
@@ -76,6 +77,8 @@ const PICK_PROBE = Object.keys(pickKeys({ a: 1, b: 2 }, ['a'])).length;
 const AFFIX_PROBE = ensurePrefix('x', '#');
 const PART_PROBE = partition([1, 2, 3], (n) => n > 1)[0].length;
 const COUNT_PROBE = countWhere([1, 2, 3], (n) => n >= 2);
+const TITLE_PROBE = titleCase('hello world');
+
 
 
 
@@ -457,6 +460,7 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
     <p
       class="text-center text-sm text-base-content/70 mb-3"
       data-testid="app-count-badge"
+      :data-title-probe="TITLE_PROBE"
       :data-count-probe="COUNT_PROBE"
       :data-part-probe="PART_PROBE"
       :data-affix-probe="AFFIX_PROBE"


### PR DESCRIPTION
## Summary
Invented: `capitalize` / `titleCase` for UI labels.

## Acceptance
- [x] Capitalize first char; titleCase on word separators
- [x] Unit + build pass

## Test plan
- `npm run test:unit -- --run src/utils/titleCase.spec.ts`