### PR TITLE
feat: compactArray helpers to drop nullish/falsy list holes

### DIFF
--- a/src/utils/compactArray.spec.ts
+++ b/src/utils/compactArray.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { compactArray, compactTruthy } from './compactArray';
+
+describe('compactArray', () => {
+  it('removes only nullish', () => {
+    expect(compactArray([1, null, 0, undefined, 2])).toEqual([1, 0, 2]);
+  });
+});
+
+describe('compactTruthy', () => {
+  it('removes falsy', () => {
+    expect(compactTruthy([1, 0, '', 2, false, 3])).toEqual([1, 2, 3]);
+  });
+});

--- a/src/utils/compactArray.ts
+++ b/src/utils/compactArray.ts
@@ -1,0 +1,17 @@
+/** Drop null and undefined entries (preserves 0, '', false). */
+export function compactArray<T>(items: readonly (T | null | undefined)[]): T[] {
+  const out: T[] = [];
+  for (const item of items) {
+    if (item != null) out.push(item);
+  }
+  return out;
+}
+
+/** Drop falsy entries (0, '', false, null, undefined). */
+export function compactTruthy<T>(items: readonly (T | null | undefined | false | 0 | '')[]): T[] {
+  const out: T[] = [];
+  for (const item of items) {
+    if (item) out.push(item as T);
+  }
+  return out;
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -34,6 +34,7 @@ import { ensurePrefix } from '@/utils/ensureAffix';
 import { partition } from '@/utils/partition';
 import { countWhere } from '@/utils/countBy';
 import { titleCase } from '@/utils/titleCase';
+import { compactArray } from '@/utils/compactArray';
 import { currentPageLink } from '@/utils/pageLink';
 import { resolveEscapeAction } from '@/utils/escapeAction';
 import { copyTextToClipboard } from '@/utils/clipboardCopy';
@@ -78,6 +79,8 @@ const AFFIX_PROBE = ensurePrefix('x', '#');
 const PART_PROBE = partition([1, 2, 3], (n) => n > 1)[0].length;
 const COUNT_PROBE = countWhere([1, 2, 3], (n) => n >= 2);
 const TITLE_PROBE = titleCase('hello world');
+const COMPACT_PROBE = compactArray([1, null, 2]).length;
+
 
 
 
@@ -460,6 +463,7 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
     <p
       class="text-center text-sm text-base-content/70 mb-3"
       data-testid="app-count-badge"
+      :data-compact-probe="COMPACT_PROBE"
       :data-title-probe="TITLE_PROBE"
       :data-count-probe="COUNT_PROBE"
       :data-part-probe="PART_PROBE"


### PR DESCRIPTION
## Summary
Invented: `compactArray` / `compactTruthy` for cleaning optional app arrays.

## Acceptance
- [x] compactArray keeps 0/''/false; compactTruthy drops falsy
- [x] Unit + build pass

## Test plan
- `npm run test:unit -- --run src/utils/compactArray.spec.ts`