### PR TITLE
feat: zipArrays and interleave list helpers

### DIFF
--- a/src/utils/zipArrays.spec.ts
+++ b/src/utils/zipArrays.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { interleave, zipArrays } from './zipArrays';
+
+describe('zipArrays', () => {
+  it('pairs up to shorter length', () => {
+    expect(zipArrays([1, 2, 3], ['a', 'b'])).toEqual([
+      [1, 'a'],
+      [2, 'b'],
+    ]);
+  });
+});
+
+describe('interleave', () => {
+  it('alternates and appends remainder', () => {
+    expect(interleave([1, 2], [10, 20, 30])).toEqual([1, 10, 2, 20, 30]);
+  });
+});

--- a/src/utils/zipArrays.ts
+++ b/src/utils/zipArrays.ts
@@ -1,0 +1,18 @@
+/** Pair elements from two arrays up to the shorter length. */
+export function zipArrays<A, B>(a: readonly A[], b: readonly B[]): Array<[A, B]> {
+  const n = Math.min(a.length, b.length);
+  const out: Array<[A, B]> = new Array(n);
+  for (let i = 0; i < n; i++) out[i] = [a[i], b[i]];
+  return out;
+}
+
+/** Interleave two arrays (a0,b0,a1,b1,...); leftovers appended. */
+export function interleave<T>(a: readonly T[], b: readonly T[]): T[] {
+  const out: T[] = [];
+  const n = Math.max(a.length, b.length);
+  for (let i = 0; i < n; i++) {
+    if (i < a.length) out.push(a[i]);
+    if (i < b.length) out.push(b[i]);
+  }
+  return out;
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -35,6 +35,7 @@ import { partition } from '@/utils/partition';
 import { countWhere } from '@/utils/countBy';
 import { titleCase } from '@/utils/titleCase';
 import { compactArray } from '@/utils/compactArray';
+import { zipArrays } from '@/utils/zipArrays';
 import { currentPageLink } from '@/utils/pageLink';
 import { resolveEscapeAction } from '@/utils/escapeAction';
 import { copyTextToClipboard } from '@/utils/clipboardCopy';
@@ -80,6 +81,8 @@ const PART_PROBE = partition([1, 2, 3], (n) => n > 1)[0].length;
 const COUNT_PROBE = countWhere([1, 2, 3], (n) => n >= 2);
 const TITLE_PROBE = titleCase('hello world');
 const COMPACT_PROBE = compactArray([1, null, 2]).length;
+const ZIP_PROBE = zipArrays([1], ['a']).length;
+
 
 
 
@@ -463,6 +466,7 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
     <p
       class="text-center text-sm text-base-content/70 mb-3"
       data-testid="app-count-badge"
+      :data-zip-probe="ZIP_PROBE"
       :data-compact-probe="COMPACT_PROBE"
       :data-title-probe="TITLE_PROBE"
       :data-count-probe="COUNT_PROBE"


### PR DESCRIPTION
## Summary
Invented: `zipArrays` / `interleave` for paired UI data.

## Acceptance
- [x] Zip to shorter length; interleave preserves leftovers
- [x] Unit + build pass

## Test plan
- `npm run test:unit -- --run src/utils/zipArrays.spec.ts`