### PR TITLE
feat: isBlank/isPresent and trimOrEmpty string guards

### DIFF
--- a/src/utils/isBlank.spec.ts
+++ b/src/utils/isBlank.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { isBlank, isPresent, trimOrEmpty } from './isBlank';
+
+describe('isBlank / isPresent', () => {
+  it('treats whitespace as blank', () => {
+    expect(isBlank('  ')).toBe(true);
+    expect(isBlank('x')).toBe(false);
+    expect(isPresent('x')).toBe(true);
+    expect(isPresent(null)).toBe(false);
+  });
+});
+
+describe('trimOrEmpty', () => {
+  it('trims and defaults nullish', () => {
+    expect(trimOrEmpty('  a  ')).toBe('a');
+    expect(trimOrEmpty(undefined)).toBe('');
+  });
+});

--- a/src/utils/isBlank.ts
+++ b/src/utils/isBlank.ts
@@ -1,0 +1,14 @@
+/** True for null, undefined, or whitespace-only string. */
+export function isBlank(value: string | null | undefined): boolean {
+  return value == null || String(value).trim() === '';
+}
+
+/** Inverse of isBlank. */
+export function isPresent(value: string | null | undefined): boolean {
+  return !isBlank(value);
+}
+
+/** Trim or return empty string for nullish. */
+export function trimOrEmpty(value: string | null | undefined): string {
+  return value == null ? '' : String(value).trim();
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -36,6 +36,7 @@ import { countWhere } from '@/utils/countBy';
 import { titleCase } from '@/utils/titleCase';
 import { compactArray } from '@/utils/compactArray';
 import { zipArrays } from '@/utils/zipArrays';
+import { isPresent } from '@/utils/isBlank';
 import { currentPageLink } from '@/utils/pageLink';
 import { resolveEscapeAction } from '@/utils/escapeAction';
 import { copyTextToClipboard } from '@/utils/clipboardCopy';
@@ -82,6 +83,8 @@ const COUNT_PROBE = countWhere([1, 2, 3], (n) => n >= 2);
 const TITLE_PROBE = titleCase('hello world');
 const COMPACT_PROBE = compactArray([1, null, 2]).length;
 const ZIP_PROBE = zipArrays([1], ['a']).length;
+const BLANK_PROBE = isPresent('ok') ? 1 : 0;
+
 
 
 
@@ -466,6 +469,7 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
     <p
       class="text-center text-sm text-base-content/70 mb-3"
       data-testid="app-count-badge"
+      :data-blank-probe="BLANK_PROBE"
       :data-zip-probe="ZIP_PROBE"
       :data-compact-probe="COMPACT_PROBE"
       :data-title-probe="TITLE_PROBE"


### PR DESCRIPTION
## Summary
Invented: `isBlank` / `isPresent` / `trimOrEmpty` for query/filter emptiness.

## Acceptance
- [x] Whitespace treated as blank; trimOrEmpty defaults nullish
- [x] Unit + build pass

## Test plan
- `npm run test:unit -- --run src/utils/isBlank.spec.ts`