### PR TITLE
feat: toggleInSet and setHasAll helpers for favorites sets

### DIFF
--- a/src/utils/toggleInSet.spec.ts
+++ b/src/utils/toggleInSet.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { setHasAll, toggleInSet } from './toggleInSet';
+
+describe('toggleInSet', () => {
+  it('adds and removes immutably', () => {
+    const a = new Set(['x']);
+    const b = toggleInSet(a, 'y');
+    expect([...b].sort()).toEqual(['x', 'y']);
+    expect(a.has('y')).toBe(false);
+    const c = toggleInSet(b, 'x');
+    expect([...c]).toEqual(['y']);
+  });
+});
+
+describe('setHasAll', () => {
+  it('checks membership of all values', () => {
+    const s = new Set([1, 2, 3]);
+    expect(setHasAll(s, [1, 3])).toBe(true);
+    expect(setHasAll(s, [1, 4])).toBe(false);
+  });
+});

--- a/src/utils/toggleInSet.ts
+++ b/src/utils/toggleInSet.ts
@@ -1,0 +1,13 @@
+/** Return a new Set with `value` toggled (add if missing, remove if present). */
+export function toggleInSet<T>(set: ReadonlySet<T>, value: T): Set<T> {
+  const next = new Set(set);
+  if (next.has(value)) next.delete(value);
+  else next.add(value);
+  return next;
+}
+
+/** True if every `values` entry is in `set`. */
+export function setHasAll<T>(set: ReadonlySet<T>, values: readonly T[]): boolean {
+  for (const v of values) if (!set.has(v)) return false;
+  return true;
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -37,6 +37,7 @@ import { titleCase } from '@/utils/titleCase';
 import { compactArray } from '@/utils/compactArray';
 import { zipArrays } from '@/utils/zipArrays';
 import { isPresent } from '@/utils/isBlank';
+import { toggleInSet } from '@/utils/toggleInSet';
 import { currentPageLink } from '@/utils/pageLink';
 import { resolveEscapeAction } from '@/utils/escapeAction';
 import { copyTextToClipboard } from '@/utils/clipboardCopy';
@@ -84,6 +85,8 @@ const TITLE_PROBE = titleCase('hello world');
 const COMPACT_PROBE = compactArray([1, null, 2]).length;
 const ZIP_PROBE = zipArrays([1], ['a']).length;
 const BLANK_PROBE = isPresent('ok') ? 1 : 0;
+const TOGGLE_PROBE = toggleInSet(new Set(['a']), 'b').size;
+
 
 
 
@@ -469,6 +472,7 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
     <p
       class="text-center text-sm text-base-content/70 mb-3"
       data-testid="app-count-badge"
+      :data-toggle-probe="TOGGLE_PROBE"
       :data-blank-probe="BLANK_PROBE"
       :data-zip-probe="ZIP_PROBE"
       :data-compact-probe="COMPACT_PROBE"


### PR DESCRIPTION
## Summary
Invented: `toggleInSet` / `setHasAll` for immutable starred-app set ops.

## Acceptance
- [x] Toggle returns new Set; setHasAll checks membership
- [x] Unit + build pass

## Test plan
- `npm run test:unit -- --run src/utils/toggleInSet.spec.ts`