### PR TITLE
feat: moveItem helper for immutable list reordering

### DIFF
--- a/src/utils/moveItem.spec.ts
+++ b/src/utils/moveItem.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { moveItem } from './moveItem';
+
+describe('moveItem', () => {
+  it('reorders immutably', () => {
+    expect(moveItem(['a', 'b', 'c'], 0, 2)).toEqual(['b', 'c', 'a']);
+    expect(moveItem(['a', 'b', 'c'], 2, 0)).toEqual(['c', 'a', 'b']);
+    const src = [1, 2];
+    const out = moveItem(src, 0, 1);
+    expect(out).toEqual([2, 1]);
+    expect(src).toEqual([1, 2]);
+  });
+});

--- a/src/utils/moveItem.ts
+++ b/src/utils/moveItem.ts
@@ -1,0 +1,12 @@
+/** Return a new array with element at `from` moved to `to` (clamped indices). */
+export function moveItem<T>(items: readonly T[], from: number, to: number): T[] {
+  const len = items.length;
+  if (len === 0) return [];
+  const src = Math.max(0, Math.min(len - 1, Math.trunc(from)));
+  const dst = Math.max(0, Math.min(len - 1, Math.trunc(to)));
+  if (src === dst) return items.slice();
+  const next = items.slice();
+  const [item] = next.splice(src, 1);
+  next.splice(dst, 0, item);
+  return next;
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -38,6 +38,7 @@ import { compactArray } from '@/utils/compactArray';
 import { zipArrays } from '@/utils/zipArrays';
 import { isPresent } from '@/utils/isBlank';
 import { toggleInSet } from '@/utils/toggleInSet';
+import { moveItem } from '@/utils/moveItem';
 import { currentPageLink } from '@/utils/pageLink';
 import { resolveEscapeAction } from '@/utils/escapeAction';
 import { copyTextToClipboard } from '@/utils/clipboardCopy';
@@ -86,6 +87,8 @@ const COMPACT_PROBE = compactArray([1, null, 2]).length;
 const ZIP_PROBE = zipArrays([1], ['a']).length;
 const BLANK_PROBE = isPresent('ok') ? 1 : 0;
 const TOGGLE_PROBE = toggleInSet(new Set(['a']), 'b').size;
+const MOVE_PROBE = moveItem([1, 2, 3], 0, 2)[2];
+
 
 
 
@@ -472,6 +475,7 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
     <p
       class="text-center text-sm text-base-content/70 mb-3"
       data-testid="app-count-badge"
+      :data-move-probe="MOVE_PROBE"
       :data-toggle-probe="TOGGLE_PROBE"
       :data-blank-probe="BLANK_PROBE"
       :data-zip-probe="ZIP_PROBE"


### PR DESCRIPTION
## Summary
Invented: `moveItem` for immutable reordering of recent/favorite lists.

## Acceptance
- [x] Moves with clamped indices; does not mutate input
- [x] Unit + build pass

## Test plan
- `npm run test:unit -- --run src/utils/moveItem.spec.ts`