### PR TITLE
feat: rotateArray helper for circular list shifts

### DIFF
--- a/src/utils/rotateArray.spec.ts
+++ b/src/utils/rotateArray.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { rotateArray } from './rotateArray';
+
+describe('rotateArray', () => {
+  it('rotates left and right immutably', () => {
+    expect(rotateArray([1, 2, 3, 4], 1)).toEqual([2, 3, 4, 1]);
+    expect(rotateArray([1, 2, 3, 4], -1)).toEqual([4, 1, 2, 3]);
+    const src = ['a', 'b'];
+    expect(rotateArray(src, 1)).toEqual(['b', 'a']);
+    expect(src).toEqual(['a', 'b']);
+  });
+
+  it('handles empty and full-cycle offsets', () => {
+    expect(rotateArray([], 3)).toEqual([]);
+    expect(rotateArray([1, 2, 3], 3)).toEqual([1, 2, 3]);
+    expect(rotateArray([1, 2, 3], 4)).toEqual([2, 3, 1]);
+  });
+});

--- a/src/utils/rotateArray.ts
+++ b/src/utils/rotateArray.ts
@@ -1,0 +1,9 @@
+/** Return a new array rotated by `offset` positions (positive = left, negative = right). */
+export function rotateArray<T>(items: readonly T[], offset: number): T[] {
+  const len = items.length;
+  if (len === 0) return [];
+  const n = Math.trunc(Number(offset)) || 0;
+  const shift = ((n % len) + len) % len;
+  if (shift === 0) return items.slice();
+  return items.slice(shift).concat(items.slice(0, shift));
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -40,6 +40,7 @@ import { isPresent } from '@/utils/isBlank';
 import { toggleInSet } from '@/utils/toggleInSet';
 import { moveItem } from '@/utils/moveItem';
 import { chunkArray } from '@/utils/chunkArray';
+import { rotateArray } from '@/utils/rotateArray';
 import { currentPageLink } from '@/utils/pageLink';
 import { resolveEscapeAction } from '@/utils/escapeAction';
 import { copyTextToClipboard } from '@/utils/clipboardCopy';
@@ -90,6 +91,7 @@ const BLANK_PROBE = isPresent('ok') ? 1 : 0;
 const TOGGLE_PROBE = toggleInSet(new Set(['a']), 'b').size;
 const MOVE_PROBE = moveItem([1, 2, 3], 0, 2)[2];
 const CHUNK_PROBE = chunkArray([1, 2, 3, 4], 2).length;
+const ROTATE_PROBE = rotateArray([1, 2, 3], 1)[0];
 
 
 
@@ -479,6 +481,7 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
       data-testid="app-count-badge"
       :data-move-probe="MOVE_PROBE"
       :data-chunk-probe="CHUNK_PROBE"
+      :data-rotate-probe="ROTATE_PROBE"
       :data-toggle-probe="TOGGLE_PROBE"
       :data-blank-probe="BLANK_PROBE"
       :data-zip-probe="ZIP_PROBE"


### PR DESCRIPTION
## Summary
Agent-invented (empty GH backlog; invent-when-empty, goal `85185cae9289`).

Adds pure `rotateArray(items, offset)` — positive offset rotates left, negative right; immutable; empty-safe.

## Acceptance criteria
- [x] Unit tests for left/right rotate, immutability, empty, modular offsets
- [x] Build passes
- [x] HomeView `data-rotate-probe` imports util on home path
- [ ] Deploy to VM + live 200 post-merge

## Test plan
- Local unit + build
- Post-merge Deploy to VM + live HEAD