### PR TITLE
feat: takeFirst/takeLast helpers for array windowing

### DIFF
--- a/src/utils/takeSlice.spec.ts
+++ b/src/utils/takeSlice.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { takeFirst, takeLast } from './takeSlice';
+
+describe('takeSlice', () => {
+  it('takeFirst returns leading slice', () => {
+    expect(takeFirst([1, 2, 3, 4], 2)).toEqual([1, 2]);
+    expect(takeFirst([1, 2], 5)).toEqual([1, 2]);
+    expect(takeFirst([1], 0)).toEqual([]);
+  });
+
+  it('takeLast returns trailing slice', () => {
+    expect(takeLast([1, 2, 3, 4], 2)).toEqual([3, 4]);
+    expect(takeLast([1, 2], 5)).toEqual([1, 2]);
+    expect(takeLast([1], 0)).toEqual([]);
+  });
+});

--- a/src/utils/takeSlice.ts
+++ b/src/utils/takeSlice.ts
@@ -1,0 +1,12 @@
+/** First `n` elements (n clamped to >= 0). */
+export function takeFirst<T>(items: readonly T[], n: number): T[] {
+  const count = Math.max(0, Math.trunc(Number(n)) || 0);
+  return items.slice(0, count);
+}
+
+/** Last `n` elements (n clamped to >= 0). */
+export function takeLast<T>(items: readonly T[], n: number): T[] {
+  const count = Math.max(0, Math.trunc(Number(n)) || 0);
+  if (count === 0) return [];
+  return items.slice(-count);
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -41,6 +41,7 @@ import { toggleInSet } from '@/utils/toggleInSet';
 import { moveItem } from '@/utils/moveItem';
 import { chunkArray } from '@/utils/chunkArray';
 import { rotateArray } from '@/utils/rotateArray';
+import { takeFirst } from '@/utils/takeSlice';
 import { currentPageLink } from '@/utils/pageLink';
 import { resolveEscapeAction } from '@/utils/escapeAction';
 import { copyTextToClipboard } from '@/utils/clipboardCopy';
@@ -92,6 +93,7 @@ const TOGGLE_PROBE = toggleInSet(new Set(['a']), 'b').size;
 const MOVE_PROBE = moveItem([1, 2, 3], 0, 2)[2];
 const CHUNK_PROBE = chunkArray([1, 2, 3, 4], 2).length;
 const ROTATE_PROBE = rotateArray([1, 2, 3], 1)[0];
+const TAKE_PROBE = takeFirst([1, 2, 3], 2).length;
 
 
 
@@ -482,6 +484,7 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
       :data-move-probe="MOVE_PROBE"
       :data-chunk-probe="CHUNK_PROBE"
       :data-rotate-probe="ROTATE_PROBE"
+      :data-take-probe="TAKE_PROBE"
       :data-toggle-probe="TOGGLE_PROBE"
       :data-blank-probe="BLANK_PROBE"
       :data-zip-probe="ZIP_PROBE"


### PR DESCRIPTION
## Summary
Agent-invented (empty backlog; invent-when-empty; goal `85185cae9289`).

`takeFirst` / `takeLast` in `src/utils/takeSlice.ts` — leading/trailing slices with non-negative clamped counts.

## Acceptance
- [x] Unit tests pass
- [x] Build passes
- [x] HomeView `data-take-probe`
- [ ] Deploy + live 200 post-merge