### PR TITLE
feat: arrayEquals helper for shallow list comparison

### DIFF
--- a/src/utils/arrayEquals.spec.ts
+++ b/src/utils/arrayEquals.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { arrayEquals } from './arrayEquals';
+
+describe('arrayEquals', () => {
+  it('compares length and elements', () => {
+    expect(arrayEquals([1, 2], [1, 2])).toBe(true);
+    expect(arrayEquals([1, 2], [1, 3])).toBe(false);
+    expect(arrayEquals([1], [1, 2])).toBe(false);
+    expect(arrayEquals([], [])).toBe(true);
+  });
+
+  it('treats NaN as equal (SameValueZero)', () => {
+    expect(arrayEquals([NaN], [NaN])).toBe(true);
+    const same = [1];
+    expect(arrayEquals(same, same)).toBe(true);
+  });
+});

--- a/src/utils/arrayEquals.ts
+++ b/src/utils/arrayEquals.ts
@@ -1,0 +1,14 @@
+/** Shallow equality for two arrays (SameValueZero element compare, length must match). */
+export function arrayEquals<T>(a: readonly T[], b: readonly T[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i];
+    const y = b[i];
+    if (x === y) continue;
+    // SameValueZero for NaN
+    if (x !== x && y !== y) continue;
+    return false;
+  }
+  return true;
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -42,6 +42,7 @@ import { moveItem } from '@/utils/moveItem';
 import { chunkArray } from '@/utils/chunkArray';
 import { rotateArray } from '@/utils/rotateArray';
 import { takeFirst } from '@/utils/takeSlice';
+import { arrayEquals } from '@/utils/arrayEquals';
 import { currentPageLink } from '@/utils/pageLink';
 import { resolveEscapeAction } from '@/utils/escapeAction';
 import { copyTextToClipboard } from '@/utils/clipboardCopy';
@@ -94,6 +95,7 @@ const MOVE_PROBE = moveItem([1, 2, 3], 0, 2)[2];
 const CHUNK_PROBE = chunkArray([1, 2, 3, 4], 2).length;
 const ROTATE_PROBE = rotateArray([1, 2, 3], 1)[0];
 const TAKE_PROBE = takeFirst([1, 2, 3], 2).length;
+const EQ_PROBE = arrayEquals([1], [1]) ? 1 : 0;
 
 
 
@@ -485,6 +487,7 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
       :data-chunk-probe="CHUNK_PROBE"
       :data-rotate-probe="ROTATE_PROBE"
       :data-take-probe="TAKE_PROBE"
+      :data-eq-probe="EQ_PROBE"
       :data-toggle-probe="TOGGLE_PROBE"
       :data-blank-probe="BLANK_PROBE"
       :data-zip-probe="ZIP_PROBE"


### PR DESCRIPTION
## Summary
Agent-invented (empty backlog; invent-when-empty; goal `85185cae9289`).

Shallow `arrayEquals(a, b)` with SameValueZero (NaN-safe) element compare.

## Acceptance
- [x] Unit tests
- [x] Build
- [x] HomeView `data-eq-probe`
- [ ] Deploy + live 200