### PR TITLE
feat: interleave helper for alternating array merge

### DIFF
--- a/src/utils/interleave.spec.ts
+++ b/src/utils/interleave.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { interleave } from './interleave';
+
+describe('interleave', () => {
+  it('merges alternating elements', () => {
+    expect(interleave([1, 3], [2, 4])).toEqual([1, 2, 3, 4]);
+    expect(interleave(['a'], ['b', 'c'])).toEqual(['a', 'b', 'c']);
+  });
+
+  it('handles empty sides', () => {
+    expect(interleave([], [1])).toEqual([1]);
+    expect(interleave([1], [])).toEqual([1]);
+    expect(interleave([], [])).toEqual([]);
+  });
+});

--- a/src/utils/interleave.ts
+++ b/src/utils/interleave.ts
@@ -1,0 +1,10 @@
+/** Interleave elements of two arrays (a0, b0, a1, b1, …); leftover tail appended. */
+export function interleave<T>(a: readonly T[], b: readonly T[]): T[] {
+  const out: T[] = [];
+  const n = Math.max(a.length, b.length);
+  for (let i = 0; i < n; i++) {
+    if (i < a.length) out.push(a[i]);
+    if (i < b.length) out.push(b[i]);
+  }
+  return out;
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -43,6 +43,7 @@ import { chunkArray } from '@/utils/chunkArray';
 import { rotateArray } from '@/utils/rotateArray';
 import { takeFirst } from '@/utils/takeSlice';
 import { arrayEquals } from '@/utils/arrayEquals';
+import { interleave } from '@/utils/interleave';
 import { currentPageLink } from '@/utils/pageLink';
 import { resolveEscapeAction } from '@/utils/escapeAction';
 import { copyTextToClipboard } from '@/utils/clipboardCopy';
@@ -96,6 +97,7 @@ const CHUNK_PROBE = chunkArray([1, 2, 3, 4], 2).length;
 const ROTATE_PROBE = rotateArray([1, 2, 3], 1)[0];
 const TAKE_PROBE = takeFirst([1, 2, 3], 2).length;
 const EQ_PROBE = arrayEquals([1], [1]) ? 1 : 0;
+const INTER_PROBE = interleave([1], [2]).length;
 
 
 
@@ -488,6 +490,7 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
       :data-rotate-probe="ROTATE_PROBE"
       :data-take-probe="TAKE_PROBE"
       :data-eq-probe="EQ_PROBE"
+      :data-inter-probe="INTER_PROBE"
       :data-toggle-probe="TOGGLE_PROBE"
       :data-blank-probe="BLANK_PROBE"
       :data-zip-probe="ZIP_PROBE"


### PR DESCRIPTION
## Summary
Agent-invented (empty backlog; invent-when-empty; goal `85185cae9289`).

`interleave(a, b)` alternates elements; leftover tail appended.

## Acceptance
- [x] Unit tests + build
- [x] HomeView `data-inter-probe`
- [ ] Deploy + live 200