### PR TITLE
feat: flattenOne helper for single-level array flatten

### DIFF
--- a/src/utils/flattenOne.spec.ts
+++ b/src/utils/flattenOne.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { flattenOne } from './flattenOne';
+
+describe('flattenOne', () => {
+  it('flattens one level', () => {
+    expect(flattenOne([1, [2, 3], 4])).toEqual([1, 2, 3, 4]);
+    expect(flattenOne([['a'], ['b', 'c']])).toEqual(['a', 'b', 'c']);
+  });
+
+  it('handles empty and flat input', () => {
+    expect(flattenOne([])).toEqual([]);
+    expect(flattenOne([1, 2])).toEqual([1, 2]);
+  });
+});

--- a/src/utils/flattenOne.ts
+++ b/src/utils/flattenOne.ts
@@ -1,0 +1,12 @@
+/** Flatten one level of nested arrays (non-arrays pass through). */
+export function flattenOne<T>(items: readonly (T | readonly T[])[]): T[] {
+  const out: T[] = [];
+  for (const item of items) {
+    if (Array.isArray(item)) {
+      for (const inner of item) out.push(inner as T);
+    } else {
+      out.push(item as T);
+    }
+  }
+  return out;
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -44,6 +44,7 @@ import { rotateArray } from '@/utils/rotateArray';
 import { takeFirst } from '@/utils/takeSlice';
 import { arrayEquals } from '@/utils/arrayEquals';
 import { interleave } from '@/utils/interleave';
+import { flattenOne } from '@/utils/flattenOne';
 import { currentPageLink } from '@/utils/pageLink';
 import { resolveEscapeAction } from '@/utils/escapeAction';
 import { copyTextToClipboard } from '@/utils/clipboardCopy';
@@ -98,6 +99,7 @@ const ROTATE_PROBE = rotateArray([1, 2, 3], 1)[0];
 const TAKE_PROBE = takeFirst([1, 2, 3], 2).length;
 const EQ_PROBE = arrayEquals([1], [1]) ? 1 : 0;
 const INTER_PROBE = interleave([1], [2]).length;
+const FLAT_PROBE = flattenOne([1, [2]]).length;
 
 
 
@@ -491,6 +493,7 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
       :data-take-probe="TAKE_PROBE"
       :data-eq-probe="EQ_PROBE"
       :data-inter-probe="INTER_PROBE"
+      :data-flat-probe="FLAT_PROBE"
       :data-toggle-probe="TOGGLE_PROBE"
       :data-blank-probe="BLANK_PROBE"
       :data-zip-probe="ZIP_PROBE"


### PR DESCRIPTION
## Summary
Agent-invented (empty backlog; invent-when-empty; goal `85185cae9289`).

`flattenOne` flattens one nesting level; non-arrays pass through.

## Acceptance
- [x] Unit tests + build
- [x] HomeView `data-flat-probe`
- [ ] Deploy + live 200