### PR TITLE
feat: difference helper for set-subtract on arrays

### DIFF
--- a/src/utils/difference.spec.ts
+++ b/src/utils/difference.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { difference } from './difference';
+
+describe('difference', () => {
+  it('returns items only in first list', () => {
+    expect(difference([1, 2, 3], [2])).toEqual([1, 3]);
+    expect(difference(['a', 'b'], ['b', 'c'])).toEqual(['a']);
+  });
+
+  it('handles empty and full overlap', () => {
+    expect(difference([], [1])).toEqual([]);
+    expect(difference([1, 2], [])).toEqual([1, 2]);
+    expect(difference([1, 2], [1, 2, 3])).toEqual([]);
+  });
+});

--- a/src/utils/difference.ts
+++ b/src/utils/difference.ts
@@ -1,0 +1,5 @@
+/** Elements in `a` that are not present in `b` (SameValueZero via Set). Order preserved from `a`. */
+export function difference<T>(a: readonly T[], b: readonly T[]): T[] {
+  const exclude = new Set(b);
+  return a.filter((item) => !exclude.has(item));
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -45,6 +45,7 @@ import { takeFirst } from '@/utils/takeSlice';
 import { arrayEquals } from '@/utils/arrayEquals';
 import { interleave } from '@/utils/interleave';
 import { flattenOne } from '@/utils/flattenOne';
+import { difference } from '@/utils/difference';
 import { currentPageLink } from '@/utils/pageLink';
 import { resolveEscapeAction } from '@/utils/escapeAction';
 import { copyTextToClipboard } from '@/utils/clipboardCopy';
@@ -100,6 +101,7 @@ const TAKE_PROBE = takeFirst([1, 2, 3], 2).length;
 const EQ_PROBE = arrayEquals([1], [1]) ? 1 : 0;
 const INTER_PROBE = interleave([1], [2]).length;
 const FLAT_PROBE = flattenOne([1, [2]]).length;
+const DIFF_PROBE = difference([1, 2], [1]).length;
 
 
 
@@ -494,6 +496,7 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
       :data-eq-probe="EQ_PROBE"
       :data-inter-probe="INTER_PROBE"
       :data-flat-probe="FLAT_PROBE"
+      :data-diff-probe="DIFF_PROBE"
       :data-toggle-probe="TOGGLE_PROBE"
       :data-blank-probe="BLANK_PROBE"
       :data-zip-probe="ZIP_PROBE"


### PR DESCRIPTION
## Summary
Agent-invented (empty backlog; invent-when-empty; goal `85185cae9289`).

`difference(a, b)` returns elements of `a` not in `b` (Set membership), preserving `a` order.

## Acceptance
- [x] Unit tests + build
- [x] HomeView `data-diff-probe`
- [ ] Deploy + live 200