### PR TITLE
feat: intersection helper for shared array elements

### DIFF
--- a/src/utils/intersection.spec.ts
+++ b/src/utils/intersection.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { intersection } from './intersection';
+
+describe('intersection', () => {
+  it('returns shared elements in first-list order', () => {
+    expect(intersection([1, 2, 3], [2, 4])).toEqual([2]);
+    expect(intersection(['a', 'b', 'c'], ['c', 'a'])).toEqual(['a', 'c']);
+  });
+
+  it('handles empty and no overlap', () => {
+    expect(intersection([], [1])).toEqual([]);
+    expect(intersection([1, 2], [])).toEqual([]);
+    expect(intersection([1], [2])).toEqual([]);
+  });
+});

--- a/src/utils/intersection.ts
+++ b/src/utils/intersection.ts
@@ -1,0 +1,5 @@
+/** Elements present in both `a` and `b` (Set membership on `b`). Order preserved from `a`. */
+export function intersection<T>(a: readonly T[], b: readonly T[]): T[] {
+  const keep = new Set(b);
+  return a.filter((item) => keep.has(item));
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -46,6 +46,7 @@ import { arrayEquals } from '@/utils/arrayEquals';
 import { interleave } from '@/utils/interleave';
 import { flattenOne } from '@/utils/flattenOne';
 import { difference } from '@/utils/difference';
+import { intersection } from '@/utils/intersection';
 import { currentPageLink } from '@/utils/pageLink';
 import { resolveEscapeAction } from '@/utils/escapeAction';
 import { copyTextToClipboard } from '@/utils/clipboardCopy';
@@ -102,6 +103,7 @@ const EQ_PROBE = arrayEquals([1], [1]) ? 1 : 0;
 const INTER_PROBE = interleave([1], [2]).length;
 const FLAT_PROBE = flattenOne([1, [2]]).length;
 const DIFF_PROBE = difference([1, 2], [1]).length;
+const ISECT_PROBE = intersection([1, 2], [2]).length;
 
 
 
@@ -497,6 +499,7 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
       :data-inter-probe="INTER_PROBE"
       :data-flat-probe="FLAT_PROBE"
       :data-diff-probe="DIFF_PROBE"
+      :data-isect-probe="ISECT_PROBE"
       :data-toggle-probe="TOGGLE_PROBE"
       :data-blank-probe="BLANK_PROBE"
       :data-zip-probe="ZIP_PROBE"


### PR DESCRIPTION
## Summary
Agent-invented (empty backlog; invent-when-empty; goal `85185cae9289`).

`intersection(a, b)` returns elements of `a` also in `b`, preserving `a` order.

## Acceptance
- [x] Unit tests + build
- [x] HomeView `data-isect-probe`
- [ ] Deploy + live 200