### PR TITLE
feat: union helper for ordered unique array merge

### DIFF
--- a/src/utils/union.spec.ts
+++ b/src/utils/union.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { union } from './union';
+
+describe('union', () => {
+  it('merges with first-seen uniqueness', () => {
+    expect(union([1, 2], [2, 3])).toEqual([1, 2, 3]);
+    expect(union(['a', 'a'], ['b'])).toEqual(['a', 'b']);
+  });
+
+  it('handles empty sides', () => {
+    expect(union([], [1])).toEqual([1]);
+    expect(union([1], [])).toEqual([1]);
+    expect(union([], [])).toEqual([]);
+  });
+});

--- a/src/utils/union.ts
+++ b/src/utils/union.ts
@@ -1,0 +1,16 @@
+/** Unique elements from `a` then `b` (first-seen wins). Preserves encounter order. */
+export function union<T>(a: readonly T[], b: readonly T[]): T[] {
+  const seen = new Set<T>();
+  const out: T[] = [];
+  for (const item of a) {
+    if (seen.has(item)) continue;
+    seen.add(item);
+    out.push(item);
+  }
+  for (const item of b) {
+    if (seen.has(item)) continue;
+    seen.add(item);
+    out.push(item);
+  }
+  return out;
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -47,6 +47,7 @@ import { interleave } from '@/utils/interleave';
 import { flattenOne } from '@/utils/flattenOne';
 import { difference } from '@/utils/difference';
 import { intersection } from '@/utils/intersection';
+import { union } from '@/utils/union';
 import { currentPageLink } from '@/utils/pageLink';
 import { resolveEscapeAction } from '@/utils/escapeAction';
 import { copyTextToClipboard } from '@/utils/clipboardCopy';
@@ -104,6 +105,7 @@ const INTER_PROBE = interleave([1], [2]).length;
 const FLAT_PROBE = flattenOne([1, [2]]).length;
 const DIFF_PROBE = difference([1, 2], [1]).length;
 const ISECT_PROBE = intersection([1, 2], [2]).length;
+const UNION_PROBE = union([1], [2]).length;
 
 
 
@@ -500,6 +502,7 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
       :data-flat-probe="FLAT_PROBE"
       :data-diff-probe="DIFF_PROBE"
       :data-isect-probe="ISECT_PROBE"
+      :data-union-probe="UNION_PROBE"
       :data-toggle-probe="TOGGLE_PROBE"
       :data-blank-probe="BLANK_PROBE"
       :data-zip-probe="ZIP_PROBE"


### PR DESCRIPTION
## Summary
Agent-invented (empty backlog; invent-when-empty; goal `85185cae9289`).

`union(a, b)` concatenates unique elements, first-seen wins, order preserved.

## Acceptance
- [x] Unit tests + build
- [x] HomeView `data-union-probe`
- [ ] Deploy + live 200