### PR TITLE
feat: capitalizeFirst helper for leading-letter casing

### DIFF
--- a/src/utils/capitalizeFirst.spec.ts
+++ b/src/utils/capitalizeFirst.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { capitalizeFirst } from './capitalizeFirst';
+
+describe('capitalizeFirst', () => {
+  it('uppercases leading char only', () => {
+    expect(capitalizeFirst('hello')).toBe('Hello');
+    expect(capitalizeFirst('Hello')).toBe('Hello');
+    expect(capitalizeFirst('hELLO')).toBe('HELLO');
+  });
+
+  it('handles empty and single char', () => {
+    expect(capitalizeFirst('')).toBe('');
+    expect(capitalizeFirst('a')).toBe('A');
+  });
+});

--- a/src/utils/capitalizeFirst.ts
+++ b/src/utils/capitalizeFirst.ts
@@ -1,0 +1,6 @@
+/** Uppercase the first character; rest unchanged. Empty/nullish-ish coerced to empty string. */
+export function capitalizeFirst(value: string): string {
+  const s = value ?? '';
+  if (!s) return '';
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -48,6 +48,7 @@ import { flattenOne } from '@/utils/flattenOne';
 import { difference } from '@/utils/difference';
 import { intersection } from '@/utils/intersection';
 import { union } from '@/utils/union';
+import { capitalizeFirst } from '@/utils/capitalizeFirst';
 import { currentPageLink } from '@/utils/pageLink';
 import { resolveEscapeAction } from '@/utils/escapeAction';
 import { copyTextToClipboard } from '@/utils/clipboardCopy';
@@ -106,6 +107,7 @@ const FLAT_PROBE = flattenOne([1, [2]]).length;
 const DIFF_PROBE = difference([1, 2], [1]).length;
 const ISECT_PROBE = intersection([1, 2], [2]).length;
 const UNION_PROBE = union([1], [2]).length;
+const CAP_PROBE = capitalizeFirst('ok');
 
 
 
@@ -503,6 +505,7 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
       :data-diff-probe="DIFF_PROBE"
       :data-isect-probe="ISECT_PROBE"
       :data-union-probe="UNION_PROBE"
+      :data-cap-probe="CAP_PROBE"
       :data-toggle-probe="TOGGLE_PROBE"
       :data-blank-probe="BLANK_PROBE"
       :data-zip-probe="ZIP_PROBE"


### PR DESCRIPTION
## Summary
Agent-invented (empty backlog; invent-when-empty; goal `85185cae9289`).

`capitalizeFirst(s)` uppercases the first character only.

## Acceptance
- [x] Unit tests + build
- [x] HomeView `data-cap-probe`
- [ ] Deploy + live 200