### PR TITLE
feat: sumBy helper for projected numeric totals

### DIFF
--- a/src/utils/sumBy.spec.ts
+++ b/src/utils/sumBy.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { sumBy } from './sumBy';
+
+describe('sumBy', () => {
+  it('sums projected numbers', () => {
+    expect(sumBy([{ n: 1 }, { n: 2 }, { n: 3 }], (x) => x.n)).toBe(6);
+    expect(sumBy([10, 20], (n) => n / 2)).toBe(15);
+  });
+
+  it('handles empty and non-finite', () => {
+    expect(sumBy([], () => 1)).toBe(0);
+    expect(sumBy([1], () => NaN)).toBe(0);
+    expect(sumBy([1], () => Infinity)).toBe(0);
+  });
+});

--- a/src/utils/sumBy.ts
+++ b/src/utils/sumBy.ts
@@ -1,0 +1,9 @@
+/** Sum numeric projections of items (non-finite values treated as 0). */
+export function sumBy<T>(items: readonly T[], project: (item: T) => number): number {
+  let total = 0;
+  for (const item of items) {
+    const n = project(item);
+    total += Number.isFinite(n) ? n : 0;
+  }
+  return total;
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -49,6 +49,7 @@ import { difference } from '@/utils/difference';
 import { intersection } from '@/utils/intersection';
 import { union } from '@/utils/union';
 import { capitalizeFirst } from '@/utils/capitalizeFirst';
+import { sumBy } from '@/utils/sumBy';
 import { currentPageLink } from '@/utils/pageLink';
 import { resolveEscapeAction } from '@/utils/escapeAction';
 import { copyTextToClipboard } from '@/utils/clipboardCopy';
@@ -108,6 +109,7 @@ const DIFF_PROBE = difference([1, 2], [1]).length;
 const ISECT_PROBE = intersection([1, 2], [2]).length;
 const UNION_PROBE = union([1], [2]).length;
 const CAP_PROBE = capitalizeFirst('ok');
+const SUM_PROBE = sumBy([1, 2], (n) => n);
 
 
 
@@ -506,6 +508,7 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
       :data-isect-probe="ISECT_PROBE"
       :data-union-probe="UNION_PROBE"
       :data-cap-probe="CAP_PROBE"
+      :data-sum-probe="SUM_PROBE"
       :data-toggle-probe="TOGGLE_PROBE"
       :data-blank-probe="BLANK_PROBE"
       :data-zip-probe="ZIP_PROBE"


### PR DESCRIPTION
## Summary
Agent-invented (empty backlog; invent-when-empty; goal `85185cae9289`).

`sumBy(items, project)` sums finite numeric projections; non-finite treated as 0.

## Acceptance
- [x] Unit tests + build
- [x] HomeView `data-sum-probe`
- [ ] Deploy + live 200