### PR TITLE
feat: average helper for finite numeric means

### DIFF
--- a/src/utils/average.spec.ts
+++ b/src/utils/average.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { average } from './average';
+
+describe('average', () => {
+  it('computes mean of finite numbers', () => {
+    expect(average([1, 2, 3])).toBe(2);
+    expect(average([10, 20])).toBe(15);
+  });
+
+  it('skips non-finite and handles empty', () => {
+    expect(average([])).toBe(0);
+    expect(average([NaN, Infinity])).toBe(0);
+    expect(average([1, NaN, 3])).toBe(2);
+  });
+});

--- a/src/utils/average.ts
+++ b/src/utils/average.ts
@@ -1,0 +1,11 @@
+/** Arithmetic mean of finite numbers in `values`; returns 0 for empty / no finite entries. */
+export function average(values: readonly number[]): number {
+  let sum = 0;
+  let count = 0;
+  for (const v of values) {
+    if (!Number.isFinite(v)) continue;
+    sum += v;
+    count += 1;
+  }
+  return count === 0 ? 0 : sum / count;
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -50,6 +50,7 @@ import { intersection } from '@/utils/intersection';
 import { union } from '@/utils/union';
 import { capitalizeFirst } from '@/utils/capitalizeFirst';
 import { sumBy } from '@/utils/sumBy';
+import { average } from '@/utils/average';
 import { currentPageLink } from '@/utils/pageLink';
 import { resolveEscapeAction } from '@/utils/escapeAction';
 import { copyTextToClipboard } from '@/utils/clipboardCopy';
@@ -110,6 +111,7 @@ const ISECT_PROBE = intersection([1, 2], [2]).length;
 const UNION_PROBE = union([1], [2]).length;
 const CAP_PROBE = capitalizeFirst('ok');
 const SUM_PROBE = sumBy([1, 2], (n) => n);
+const AVG_PROBE = average([2, 4]);
 
 
 
@@ -509,6 +511,7 @@ watch([searchQuery, selectedCategory, selectedUseCase], ([query, category, useCa
       :data-union-probe="UNION_PROBE"
       :data-cap-probe="CAP_PROBE"
       :data-sum-probe="SUM_PROBE"
+      :data-avg-probe="AVG_PROBE"
       :data-toggle-probe="TOGGLE_PROBE"
       :data-blank-probe="BLANK_PROBE"
       :data-zip-probe="ZIP_PROBE"


### PR DESCRIPTION
## Summary
Agent-invented (empty backlog; invent-when-empty; goal `85185cae9289`).

`average(values)` returns arithmetic mean of finite numbers; 0 if none.

## Acceptance
- [x] Unit tests + build
- [x] HomeView `data-avg-probe`
- [ ] Deploy + live 200