### PR TITLE
Add local deploy skill and deploy-local.sh

### DIFF
--- a/.grok/skills/guia-deploy/SKILL.md
+++ b/.grok/skills/guia-deploy/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: guia-deploy
+description: >
+  Local build/deploy for sovereinia/guia using scripts/deploy-local.sh (mirrors
+  .github/workflows/deploy-to-vm.yml). Trigger on /guia-deploy, deploy guia,
+  ship guia, verify guia build, smoke-test sovereinia.org/guia, or skip slow
+  GitHub Actions when VM SSH is available. Prefer this over reimplementing npm/rsync/curl.
+compatibility: >
+  Node 22+ (required; Node 18 fails vite/tailwind native bindings). npm, curl.
+  rsync+ssh only for rsync/deploy/ship. deploy@sovereinia.org key for production push.
+metadata:
+  short-description: "guia local verify/build/deploy/smoke via deploy-local.sh"
+---
+
+# guia-deploy
+
+Fast local path for the same pipeline CI runs on `main`. **Do not modify or remove** `.github/workflows/deploy-to-vm.yml` — keep Actions for merges and contributors without VM access.
+
+Entrypoint (always from **guia repo root**):
+
+```bash
+chmod +x scripts/deploy-local.sh   # once if needed
+./scripts/deploy-local.sh <cmd>
+```
+
+Script enforces Node 22+ and checks for `rsync`/`ssh`/`curl` on relevant steps.
+
+## Command chooser (pick one)
+
+| User intent | Command | Needs SSH key? | Touches prod? |
+|-------------|---------|----------------|---------------|
+| Tests + build only / PR gate | `verify` | No | No |
+| Just produce `dist/` | `build` | No | No |
+| Is production up? | `smoke` | No | No (read-only HTTP) |
+| Push current tree fast (no unit tests) | `deploy` | Yes | **Yes** |
+| Push with checks (default for “ship/release/deploy properly”) | `ship` | Yes | **Yes** |
+| Only sync existing `dist/` | `rsync` | Yes | **Yes** |
+
+If unclear and they want production updated → **`ship`**. If no deploy key / sandbox / contributor → **`verify`** only and say CI will deploy on `main` merge.
+
+## Preflight (agent does this before running)
+
+1. **Repo root** — has `package.json`, `scripts/deploy-local.sh`, `vite.config.ts` with `base: '/guia/'`.
+2. **Node** — `node -v` major ≥ 22. If not, stop and tell user to install/use Node 22 (CI uses `node-version: 22`). Do not proceed with Node 18 even if npm ci “works”.
+3. **Git context** (before any prod command) — `git status -sb` and `git log -1 --oneline`. Warn if dirty; proceed only if user accepts deploying this working tree.
+4. **Prod commands only** (`rsync`/`deploy`/`ship`):
+   - `command -v rsync ssh curl`
+   - Key: file exists at `SSH_IDENTITY_FILE` or `~/.ssh/deploy_key`, **or** agent has a key that works for `deploy@sovereinia.org`. If neither, run `verify`/`smoke` instead and explain how to set the key (same material as CI `secrets.SSH_PRIVATE_KEY`).
+
+Optional env (defaults match workflow `env:`):
+
+| Var | Default |
+|-----|---------|
+| `DEPLOY_HOST` | `sovereinia.org` |
+| `DEPLOY_USER` | `deploy` |
+| `DEPLOY_PATH` | `/srv/apps/sovereinia/guia/` |
+| `SMOKE_URL` | `https://sovereinia.org/guia/` |
+| `SSH_IDENTITY_FILE` | `~/.ssh/deploy_key` if present |
+| `FORCE_NPM_CI=1` | force `npm ci` |
+| `SKIP_NPM_CI=1` | skip install when `node_modules` exists |
+
+Never change `DEPLOY_PATH` unless the user explicitly sets it (rsync `--delete` is destructive on the wrong path).
+
+## Execute
+
+```bash
+./scripts/deploy-local.sh verify|build|smoke|deploy|ship|rsync
+```
+
+- Do **not** hand-roll parallel npm/rsync/curl unless the script is missing; fix/restore the script instead.
+- One shot; on failure stop (no retry loops). Re-run only after fixing the reported error or on explicit user request.
+- `deploy`/`ship` order: build or verify → rsync → smoke. If rsync fails, smoke is skipped (script stops).
+
+## Interpret results
+
+| Outcome | What to report |
+|---------|----------------|
+| `verify`/`build` OK | Short SHA; tests passed (verify); `dist/` built with `/guia/` assets |
+| `smoke` OK | `GET https://sovereinia.org/guia/ -> 200` |
+| `ship`/`deploy` OK | SHA + branch/dirty note; build OK; rsync OK; smoke 200; live URL |
+| Node < 22 | Install/switch Node 22; cite CI workflow setup-node |
+| `missing command: rsync` | Install rsync (or use verify/smoke only in this environment) |
+| `Permission denied` / rsync 255 | Deploy key not loaded; point at `SSH_IDENTITY_FILE` / `~/.ssh/deploy_key` / `ssh-add`; do not fall back to force-pushing unless user wants Actions deploy via `main` |
+| Unit/build errors | Paste failing command output; fix only if user asked to fix |
+| Smoke non-200 after successful rsync | Remote/nginx issue possible; run `smoke` once more; optional `ssh deploy@… 'ls /srv/apps/sovereinia/guia/'` if SSH works — do not mass re-rsync |
+
+## CI vs local
+
+| | GitHub Actions | This skill |
+|--|----------------|------------|
+| Trigger | push `main`, `workflow_dispatch` | agent / maintainer on demand |
+| Node | 22 on runner | 22+ on your machine (script-enforced) |
+| Auth | `secrets.SSH_PRIVATE_KEY` | local key / agent |
+| Artifact | runner `dist/` | local `dist/` |
+| Overwrite risk | last successful rsync wins (Actions or local) | same — coordinate with team |
+
+Contributors without VM SSH: run **`verify`** locally; merge/push `main` lets Actions deploy.
+
+## Do not
+
+- Commit keys, tokens, or `~/.ssh/*`
+- Disable/remove/bypass the Deploy to VM workflow
+- Deploy from an unknown/wrong directory or override `DEPLOY_PATH` casually
+- Claim production was updated unless rsync completed and smoke returned 200

--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Local mirror of .github/workflows/deploy-to-vm.yml
+# Commands: verify | build | rsync | smoke | deploy | ship
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Match CI (actions/setup-node node-version: 22)
+node_major="$(node -p "process.versions.node.split('.')[0]" 2>/dev/null || echo 0)"
+if [[ "$node_major" -lt 22 ]]; then
+  echo "error: Node 22+ required (CI uses 22); current: $(node -v 2>/dev/null || echo none)" >&2
+  exit 1
+fi
+
+DEPLOY_HOST="${DEPLOY_HOST:-sovereinia.org}"
+DEPLOY_USER="${DEPLOY_USER:-deploy}"
+DEPLOY_PATH="${DEPLOY_PATH:-/srv/apps/sovereinia/guia/}"
+SMOKE_URL="${SMOKE_URL:-https://sovereinia.org/guia/}"
+
+die() { echo "error: $*" >&2; exit 1; }
+
+ensure_deps() {
+  if [[ ! -d node_modules ]] || [[ package-lock.json -nt node_modules ]] || [[ "${FORCE_NPM_CI:-}" == "1" ]]; then
+    [[ "${SKIP_NPM_CI:-}" == "1" && -d node_modules ]] || npm ci
+  fi
+}
+
+do_build()  { ensure_deps; npm run build; [[ -d dist ]] || die "no dist/"; }
+do_verify() { ensure_deps; npm run test:unit -- --run; npm run build; [[ -d dist ]] || die "no dist/"; }
+
+ssh_base() {
+  local opts=(-o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new)
+  local key="${SSH_IDENTITY_FILE:-${HOME}/.ssh/deploy_key}"
+  [[ -f "$key" ]] && opts+=(-i "$key")
+  printf '%q ' "${opts[@]}"
+}
+
+need_cmd() { command -v "$1" >/dev/null 2>&1 || die "missing command: $1"; }
+
+do_rsync() {
+  [[ -d dist ]] || die "run build/verify first"
+  need_cmd rsync
+  need_cmd ssh
+  # shellcheck disable=SC2046
+  rsync -az --delete -e "ssh $(ssh_base)" dist/ "${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_PATH}"
+}
+
+do_smoke() {
+  need_cmd curl
+  local code
+  code="$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 "$SMOKE_URL")"
+  echo "GET $SMOKE_URL -> $code"
+  [[ "$code" == "200" ]] || die "smoke failed"
+}
+
+case "${1:-}" in
+  build)  do_build ;;
+  verify) do_verify ;;
+  rsync)  do_rsync ;;
+  smoke)  do_smoke ;;
+  deploy) do_build && do_rsync && do_smoke ;;
+  ship)   do_verify && do_rsync && do_smoke ;;
+  *) echo "usage: $0 {verify|build|rsync|smoke|deploy|ship}" >&2; exit 1 ;;
+esac


### PR DESCRIPTION
## Summary
- Add `scripts/deploy-local.sh` as a local mirror of `.github/workflows/deploy-to-vm.yml` (`verify` | `build` | `rsync` | `smoke` | `deploy` | `ship`)
- Add Grok skill `.grok/skills/guia-deploy/SKILL.md` so agents use the script instead of ad-hoc npm/rsync/curl
- Does **not** change the CI/CD workflow; Actions remains the path for `main` merges and contributors without VM SSH

## Test plan
- [x] `./scripts/deploy-local.sh smoke` → 200 on https://sovereinia.org/guia/
- [x] `./scripts/deploy-local.sh verify` on Node 22 (tests + build)
- [ ] `./scripts/deploy-local.sh ship` with deploy key (maintainer only)
- [ ] Fresh agent session: ambiguous “is /guia up?” / “ship working tree” picks skill without being told the name